### PR TITLE
Add GitHub Actions CI workflow with tests and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Ruff check
+        run: ruff check custom_components tests
+
+      - name: Ruff format check
+        run: ruff format --check custom_components tests
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install \
+            pytest pytest-asyncio pytest-cov \
+            pytest-homeassistant-custom-component \
+            requests grpcio protobuf
+
+      - name: Run tests
+        run: pytest tests/ -v --cov --cov-report=term-missing
+
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration
+
+      - name: hassfest validation
+        uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: HACS validation
-        uses: hacs/action@main
-        with:
-          category: integration
-
       - name: hassfest validation
         uses: home-assistant/actions/hassfest@master

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ dist/
 build/
 .env
 *.log
+.pytest_cache/
+.coverage
+htmlcov/
+.ruff_cache/
+.venv/

--- a/custom_components/polestar_soc/__init__.py
+++ b/custom_components/polestar_soc/__init__.py
@@ -24,8 +24,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(
-        entry, PLATFORMS
-    ):
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok

--- a/custom_components/polestar_soc/config_flow.py
+++ b/custom_components/polestar_soc/config_flow.py
@@ -6,7 +6,6 @@ import logging
 from typing import Any
 
 import voluptuous as vol
-
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
@@ -28,9 +27,7 @@ class PolestarSOCConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
 
@@ -43,9 +40,7 @@ class PolestarSOCConfigFlow(ConfigFlow, domain=DOMAIN):
 
             api = PolestarAPI()
             try:
-                tokens = await self.hass.async_add_executor_job(
-                    api.login, email, password
-                )
+                tokens = await self.hass.async_add_executor_job(api.login, email, password)
             except ConfigEntryAuthFailed:
                 errors["base"] = "invalid_auth"
             except Exception:
@@ -54,9 +49,7 @@ class PolestarSOCConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 # Validate we can fetch vehicles
                 try:
-                    vehicles = await self.hass.async_add_executor_job(
-                        api.get_vehicles
-                    )
+                    vehicles = await self.hass.async_add_executor_job(api.get_vehicles)
                 except Exception:
                     _LOGGER.exception("Failed to fetch vehicles")
                     errors["base"] = "cannot_connect"
@@ -80,9 +73,7 @@ class PolestarSOCConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_reauth(
-        self, entry_data: dict[str, Any]
-    ) -> ConfigFlowResult:
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
         """Handle re-authentication."""
         return await self.async_step_reauth_confirm()
 
@@ -98,18 +89,14 @@ class PolestarSOCConfigFlow(ConfigFlow, domain=DOMAIN):
 
             api = PolestarAPI()
             try:
-                tokens = await self.hass.async_add_executor_job(
-                    api.login, email, password
-                )
+                tokens = await self.hass.async_add_executor_job(api.login, email, password)
             except ConfigEntryAuthFailed:
                 errors["base"] = "invalid_auth"
             except Exception:
                 _LOGGER.exception("Unexpected error during re-auth")
                 errors["base"] = "cannot_connect"
             else:
-                entry = self.hass.config_entries.async_get_entry(
-                    self.context["entry_id"]
-                )
+                entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
                 if entry:
                     self.hass.config_entries.async_update_entry(
                         entry,

--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -10,7 +10,6 @@ import re
 from urllib.parse import parse_qs, urlparse
 
 import requests
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -51,9 +50,7 @@ class PolestarAPI:
     def login(self, email: str, password: str) -> dict:
         """Perform full OAuth2 Authorization Code + PKCE login."""
         code_verifier = _b64urlencode(os.urandom(32))
-        code_challenge = _b64urlencode(
-            hashlib.sha256(code_verifier.encode()).digest()
-        )
+        code_challenge = _b64urlencode(hashlib.sha256(code_verifier.encode()).digest())
         state = _b64urlencode(os.urandom(12))
 
         session = requests.Session()
@@ -76,9 +73,7 @@ class PolestarAPI:
         resp.raise_for_status()
 
         # Step 2: Extract resume path
-        match = re.search(
-            r'(/as/[^/]+/resume/as/authorization\.ping)', resp.text
-        )
+        match = re.search(r"(/as/[^/]+/resume/as/authorization\.ping)", resp.text)
         if not match:
             raise UpdateFailed("Could not find login form endpoint")
 
@@ -99,9 +94,7 @@ class PolestarAPI:
         if resp.status_code not in (302, 303):
             if "ERR001" in resp.text or "authMessage" in resp.text:
                 raise ConfigEntryAuthFailed("Invalid email or password")
-            raise UpdateFailed(
-                f"Unexpected login response ({resp.status_code})"
-            )
+            raise UpdateFailed(f"Unexpected login response ({resp.status_code})")
 
         redirect_url = resp.headers.get("Location", "")
         parsed = urlparse(redirect_url)
@@ -124,9 +117,7 @@ class PolestarAPI:
             params = parse_qs(parsed.query)
 
         if "code" not in params:
-            resp = session.get(
-                redirect_url, allow_redirects=False, timeout=HTTP_TIMEOUT
-            )
+            resp = session.get(redirect_url, allow_redirects=False, timeout=HTTP_TIMEOUT)
             if resp.status_code in (302, 303):
                 redirect_url = resp.headers.get("Location", "")
                 parsed = urlparse(redirect_url)
@@ -191,9 +182,7 @@ class PolestarAPI:
         if variables:
             payload["variables"] = variables
 
-        resp = requests.post(
-            API_URL, json=payload, headers=headers, timeout=HTTP_TIMEOUT
-        )
+        resp = requests.post(API_URL, json=payload, headers=headers, timeout=HTTP_TIMEOUT)
         resp.raise_for_status()
         result = resp.json()
 
@@ -268,9 +257,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
 
         # Full re-login
         try:
-            await self.hass.async_add_executor_job(
-                self.api.login, self._email, self._password
-            )
+            await self.hass.async_add_executor_job(self.api.login, self._email, self._password)
             self._update_stored_tokens()
         except ConfigEntryAuthFailed:
             raise

--- a/custom_components/polestar_soc/manifest.json
+++ b/custom_components/polestar_soc/manifest.json
@@ -3,7 +3,7 @@
   "name": "Polestar State of Charge",
   "codeowners": [],
   "config_flow": true,
-  "documentation": "",
+  "documentation": "https://github.com/2ndalpha/polestar-home-assistant",
   "iot_class": "cloud_polling",
   "requirements": ["requests>=2.28.0", "grpcio>=1.60.0", "protobuf>=4.25.0"],
   "version": "1.0.0"

--- a/custom_components/polestar_soc/number.py
+++ b/custom_components/polestar_soc/number.py
@@ -34,9 +34,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class PolestarChargeLimitNumber(
-    CoordinatorEntity[PolestarCoordinator], NumberEntity
-):
+class PolestarChargeLimitNumber(CoordinatorEntity[PolestarCoordinator], NumberEntity):
     """Charge limit number entity — sets the target SOC percentage."""
 
     _attr_has_entity_name = True

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -33,6 +33,7 @@ _METHOD_SET_CHARGE_TIMER = f"{_SVC_CHARGE_TIMER}/SetGlobalChargeTimer"
 # ---------------------------------------------------------------------------
 # Wire types: 0=varint, 2=length-delimited
 
+
 def _encode_varint(value: int) -> bytes:
     """Encode an integer as a protobuf varint."""
     pieces = []
@@ -241,6 +242,7 @@ def _parse_charge_timer_response(data: bytes) -> dict:
 # Raw serializer/deserializer for grpc channel methods
 # ---------------------------------------------------------------------------
 
+
 def _identity_serialize(data: bytes) -> bytes:
     return data
 
@@ -274,9 +276,7 @@ class PccsClient:
         """Get or create the gRPC channel."""
         if self._channel is None:
             credentials = grpc.ssl_channel_credentials()
-            self._channel = grpc.secure_channel(
-                f"{PCCS_API_HOST}:443", credentials
-            )
+            self._channel = grpc.secure_channel(f"{PCCS_API_HOST}:443", credentials)
         return self._channel
 
     def _metadata(self, vin: str) -> list[tuple[str, str]]:
@@ -364,9 +364,7 @@ class PccsClient:
             request_serializer=_identity_serialize,
             response_deserializer=_identity_deserialize,
         )
-        request = _build_set_charge_timer_request(
-            start_hour, start_min, end_hour, end_min
-        )
+        request = _build_set_charge_timer_request(start_hour, start_min, end_hour, end_min)
         try:
             response = method(request, metadata=self._metadata(vin), timeout=30)
             return _parse_charge_timer_response(response)

--- a/custom_components/polestar_soc/sensor.py
+++ b/custom_components/polestar_soc/sensor.py
@@ -29,22 +29,16 @@ class PolestarSensorDescription(SensorEntityDescription):
     value_fn: Callable[[dict, dict | None, dict | None], object]
 
 
-def _battery_soc(
-    vehicle: dict, battery: dict | None, odometer: dict | None
-) -> int | None:
+def _battery_soc(vehicle: dict, battery: dict | None, odometer: dict | None) -> int | None:
     if battery is None:
         return None
     return battery.get("batteryChargeLevelPercentage")
 
 
-def _charging_status(
-    vehicle: dict, battery: dict | None, odometer: dict | None
-) -> str:
+def _charging_status(vehicle: dict, battery: dict | None, odometer: dict | None) -> str:
     if battery is None:
         return "Unknown"
-    return PolestarCoordinator.format_charging_status(
-        battery.get("chargingStatus")
-    )
+    return PolestarCoordinator.format_charging_status(battery.get("chargingStatus"))
 
 
 def _charging_time_remaining(
@@ -55,9 +49,7 @@ def _charging_time_remaining(
     return battery.get("estimatedChargingTimeToFullMinutes")
 
 
-def _odometer_km(
-    vehicle: dict, battery: dict | None, odometer: dict | None
-) -> float | None:
+def _odometer_km(vehicle: dict, battery: dict | None, odometer: dict | None) -> float | None:
     if odometer is None:
         return None
     meters = odometer.get("odometerMeters")
@@ -111,9 +103,7 @@ async def async_setup_entry(
     for vehicle in coordinator.data.get("vehicles", []):
         vin = vehicle["vin"]
         for description in SENSOR_DESCRIPTIONS:
-            entities.append(
-                PolestarSensor(coordinator, description, vehicle, vin)
-            )
+            entities.append(PolestarSensor(coordinator, description, vehicle, vin))
 
     async_add_entities(entities)
 

--- a/custom_components/polestar_soc/time.py
+++ b/custom_components/polestar_soc/time.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import time
 import logging
+from datetime import time
 
 from homeassistant.components.time import TimeEntity
 from homeassistant.config_entries import ConfigEntry
@@ -29,23 +29,13 @@ async def async_setup_entry(
     entities: list[PolestarChargeTimeEntity] = []
     for vehicle in coordinator.data.get("vehicles", []):
         vin = vehicle["vin"]
-        entities.append(
-            PolestarChargeTimeEntity(
-                coordinator, vehicle, vin, time_key="start"
-            )
-        )
-        entities.append(
-            PolestarChargeTimeEntity(
-                coordinator, vehicle, vin, time_key="end"
-            )
-        )
+        entities.append(PolestarChargeTimeEntity(coordinator, vehicle, vin, time_key="start"))
+        entities.append(PolestarChargeTimeEntity(coordinator, vehicle, vin, time_key="end"))
 
     async_add_entities(entities)
 
 
-class PolestarChargeTimeEntity(
-    CoordinatorEntity[PolestarCoordinator], TimeEntity
-):
+class PolestarChargeTimeEntity(CoordinatorEntity[PolestarCoordinator], TimeEntity):
     """Charge timer time entity — sets charging start or end time."""
 
     _attr_has_entity_name = True
@@ -110,9 +100,7 @@ class PolestarChargeTimeEntity(
         Both start and end times are sent together in a single gRPC call,
         so we read the current opposite value from coordinator data.
         """
-        timer_data = (
-            self.coordinator.data.get("charge_timer", {}).get(self._vin) or {}
-        )
+        timer_data = self.coordinator.data.get("charge_timer", {}).get(self._vin) or {}
 
         if self._time_key == "start":
             start_h, start_m = value.hour, value.minute

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "polestar-soc"
+version = "1.0.0"
+description = "Polestar State of Charge – Home Assistant custom integration"
+requires-python = ">=3.12"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.coverage.run]
+source = ["custom_components/polestar_soc"]
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 30

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+"""Shared fixtures for Polestar SOC tests."""
+
+import pytest
+
+# Activate the pytest-homeassistant-custom-component plugin
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture
+def sample_vehicle():
+    """Return a sample vehicle dict as returned by the GraphQL API."""
+    return {
+        "vin": "YSMYKEAE1RB000001",
+        "internalVehicleIdentifier": "abc123",
+        "modelYear": 2025,
+        "content": {"model": {"code": "534", "name": "Polestar 4"}},
+        "hasPerformancePackage": False,
+        "registrationNo": "ABC123",
+        "deliveryDate": "2025-03-01",
+        "currentPlannedDeliveryDate": "2025-03-01",
+    }
+
+
+@pytest.fixture
+def sample_battery():
+    """Return a sample battery telemetry dict."""
+    return {
+        "vin": "YSMYKEAE1RB000001",
+        "batteryChargeLevelPercentage": 72,
+        "chargingStatus": "CHARGING_STATUS_CHARGING",
+        "estimatedChargingTimeToFullMinutes": 95,
+    }
+
+
+@pytest.fixture
+def sample_odometer():
+    """Return a sample odometer telemetry dict."""
+    return {
+        "vin": "YSMYKEAE1RB000001",
+        "odometerMeters": 12345678,
+    }

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,0 +1,52 @@
+"""Tests for constants and configuration values."""
+
+from custom_components.polestar_soc.const import (
+    API_URL,
+    CHARGING_STATUS_MAP,
+    CLIENT_ID,
+    DOMAIN,
+    OIDC_AUTH_URL,
+    OIDC_BASE_URL,
+    OIDC_TOKEN_URL,
+    PCCS_API_HOST,
+    REDIRECT_URI,
+    SCAN_INTERVAL,
+)
+
+
+def test_domain_is_set():
+    assert DOMAIN == "polestar_soc"
+
+
+def test_scan_interval_positive():
+    assert SCAN_INTERVAL.total_seconds() > 0
+
+
+def test_oauth_urls_use_https():
+    for url in (OIDC_BASE_URL, OIDC_AUTH_URL, OIDC_TOKEN_URL, REDIRECT_URI, API_URL):
+        assert url.startswith("https://"), f"{url} does not use HTTPS"
+
+
+def test_client_id_non_empty():
+    assert CLIENT_ID
+
+
+def test_pccs_host_non_empty():
+    assert PCCS_API_HOST
+
+
+def test_charging_status_map_has_expected_keys():
+    expected_keys = {
+        "CHARGING_STATUS_CHARGING",
+        "CHARGING_STATUS_IDLE",
+        "CHARGING_STATUS_DONE",
+        "CHARGING_STATUS_FAULT",
+        "CHARGING_STATUS_UNSPECIFIED",
+        "CHARGING_STATUS_SCHEDULED",
+    }
+    assert set(CHARGING_STATUS_MAP.keys()) == expected_keys
+
+
+def test_charging_status_map_values_are_non_empty_strings():
+    for key, value in CHARGING_STATUS_MAP.items():
+        assert isinstance(value, str) and value, f"Bad value for {key}"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,59 @@
+"""Tests for coordinator utility functions."""
+
+import base64
+
+from custom_components.polestar_soc.coordinator import (
+    PolestarCoordinator,
+    _b64urlencode,
+)
+
+
+class TestB64UrlEncode:
+    def test_simple_bytes(self):
+        result = _b64urlencode(b"hello")
+        # URL-safe base64 of "hello" without padding
+        expected = base64.urlsafe_b64encode(b"hello").rstrip(b"=").decode()
+        assert result == expected
+
+    def test_no_padding(self):
+        # Ensure no '=' padding characters
+        for length in range(1, 50):
+            result = _b64urlencode(bytes(range(length)))
+            assert "=" not in result
+
+    def test_url_safe_chars(self):
+        # Standard base64 uses + and /, URL-safe uses - and _
+        # Use bytes that produce + and / in standard base64
+        data = b"\xfb\xff\xfe"
+        result = _b64urlencode(data)
+        assert "+" not in result
+        assert "/" not in result
+
+    def test_empty_input(self):
+        result = _b64urlencode(b"")
+        assert result == ""
+
+
+class TestFormatChargingStatus:
+    def test_known_statuses(self):
+        assert PolestarCoordinator.format_charging_status("CHARGING_STATUS_CHARGING") == "Charging"
+        assert PolestarCoordinator.format_charging_status("CHARGING_STATUS_IDLE") == "Idle"
+        assert PolestarCoordinator.format_charging_status("CHARGING_STATUS_DONE") == "Fully charged"
+        assert PolestarCoordinator.format_charging_status("CHARGING_STATUS_FAULT") == "Fault"
+        assert (
+            PolestarCoordinator.format_charging_status("CHARGING_STATUS_UNSPECIFIED") == "Unknown"
+        )
+        assert (
+            PolestarCoordinator.format_charging_status("CHARGING_STATUS_SCHEDULED") == "Scheduled"
+        )
+
+    def test_none_returns_unknown(self):
+        assert PolestarCoordinator.format_charging_status(None) == "Unknown"
+
+    def test_empty_string_returns_unknown(self):
+        assert PolestarCoordinator.format_charging_status("") == "Unknown"
+
+    def test_unknown_status_formatted(self):
+        # Unknown statuses should be formatted by stripping prefix and title-casing
+        result = PolestarCoordinator.format_charging_status("CHARGING_STATUS_NEW_VALUE")
+        assert result == "New Value"

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -1,0 +1,269 @@
+"""Tests for PCCS protobuf wire-format helpers."""
+
+import pytest
+
+from custom_components.polestar_soc.pccs import (
+    _build_set_charge_timer_request,
+    _build_set_target_soc_request,
+    _build_time_of_day,
+    _decode_message,
+    _decode_varint,
+    _encode_field_bytes,
+    _encode_field_varint,
+    _encode_varint,
+    _get_bool,
+    _get_int,
+    _get_submessage,
+    _parse_charge_timer_response,
+    _parse_target_soc_response,
+)
+
+# ---------------------------------------------------------------------------
+# Varint encoding / decoding
+# ---------------------------------------------------------------------------
+
+
+class TestEncodeVarint:
+    def test_zero(self):
+        assert _encode_varint(0) == b"\x00"
+
+    def test_single_byte(self):
+        assert _encode_varint(1) == b"\x01"
+        assert _encode_varint(127) == b"\x7f"
+
+    def test_two_bytes(self):
+        # 128 = 0x80 → 0x80 0x01
+        assert _encode_varint(128) == b"\x80\x01"
+        assert _encode_varint(300) == b"\xac\x02"
+
+    def test_large_value(self):
+        result = _encode_varint(100000)
+        # Roundtrip check
+        decoded, pos = _decode_varint(result, 0)
+        assert decoded == 100000
+        assert pos == len(result)
+
+
+class TestDecodeVarint:
+    def test_zero(self):
+        val, pos = _decode_varint(b"\x00", 0)
+        assert val == 0
+        assert pos == 1
+
+    def test_single_byte(self):
+        val, pos = _decode_varint(b"\x01", 0)
+        assert val == 1
+
+    def test_multi_byte(self):
+        val, pos = _decode_varint(b"\xac\x02", 0)
+        assert val == 300
+
+    def test_with_offset(self):
+        data = b"\xff\xac\x02"
+        val, pos = _decode_varint(data, 1)
+        assert val == 300
+        assert pos == 3
+
+    def test_truncated_raises(self):
+        with pytest.raises(ValueError, match="Truncated"):
+            _decode_varint(b"\x80", 0)  # continuation bit set, no next byte
+
+    def test_roundtrip_various_values(self):
+        for value in [0, 1, 127, 128, 255, 256, 16383, 16384, 2**21 - 1, 2**21]:
+            encoded = _encode_varint(value)
+            decoded, pos = _decode_varint(encoded, 0)
+            assert decoded == value, f"Roundtrip failed for {value}"
+            assert pos == len(encoded)
+
+
+# ---------------------------------------------------------------------------
+# Field encoding
+# ---------------------------------------------------------------------------
+
+
+class TestEncodeFieldVarint:
+    def test_field_1_value_80(self):
+        result = _encode_field_varint(1, 80)
+        decoded = _decode_message(result)
+        assert decoded[1] == [80]
+
+    def test_field_number_preserved(self):
+        for fn in (1, 2, 5, 15):
+            result = _encode_field_varint(fn, 42)
+            decoded = _decode_message(result)
+            assert fn in decoded
+            assert decoded[fn] == [42]
+
+
+class TestEncodeFieldBytes:
+    def test_simple(self):
+        payload = b"hello"
+        result = _encode_field_bytes(1, payload)
+        decoded = _decode_message(result)
+        assert decoded[1] == [b"hello"]
+
+
+# ---------------------------------------------------------------------------
+# Message decoding
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeMessage:
+    def test_empty(self):
+        assert _decode_message(b"") == {}
+
+    def test_single_varint_field(self):
+        data = _encode_field_varint(1, 42)
+        fields = _decode_message(data)
+        assert fields == {1: [42]}
+
+    def test_multiple_fields(self):
+        data = _encode_field_varint(1, 10) + _encode_field_varint(2, 20)
+        fields = _decode_message(data)
+        assert fields == {1: [10], 2: [20]}
+
+    def test_nested_message(self):
+        inner = _encode_field_varint(1, 99)
+        outer = _encode_field_bytes(3, inner)
+        fields = _decode_message(outer)
+        assert 3 in fields
+        assert isinstance(fields[3][0], bytes)
+
+    def test_unsupported_wire_type_raises(self):
+        # Wire type 3 (start group) is unsupported
+        bad_tag = (1 << 3) | 3  # field 1, wire type 3
+        data = _encode_varint(bad_tag)
+        with pytest.raises(ValueError, match="Unsupported wire type"):
+            _decode_message(data)
+
+
+# ---------------------------------------------------------------------------
+# Helper extractors
+# ---------------------------------------------------------------------------
+
+
+class TestGetInt:
+    def test_existing_field(self):
+        fields = {1: [42], 2: [100]}
+        assert _get_int(fields, 1) == 42
+
+    def test_missing_field_default(self):
+        assert _get_int({}, 1) == 0
+        assert _get_int({}, 1, 99) == 99
+
+
+class TestGetBool:
+    def test_true(self):
+        assert _get_bool({1: [1]}, 1) is True
+
+    def test_false_zero(self):
+        assert _get_bool({1: [0]}, 1) is False
+
+    def test_false_missing(self):
+        assert _get_bool({}, 1) is False
+
+
+class TestGetSubmessage:
+    def test_valid(self):
+        inner = _encode_field_varint(1, 7)
+        fields = {5: [inner]}
+        sub = _get_submessage(fields, 5)
+        assert sub == {1: [7]}
+
+    def test_missing(self):
+        assert _get_submessage({}, 5) is None
+
+    def test_non_bytes(self):
+        # If the field is a varint rather than bytes, should return None
+        assert _get_submessage({5: [42]}, 5) is None
+
+
+# ---------------------------------------------------------------------------
+# Message builders
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSetTargetSocRequest:
+    def test_roundtrip(self):
+        data = _build_set_target_soc_request(80)
+        fields = _decode_message(data)
+        assert fields[1] == [80]
+
+
+class TestBuildTimeOfDay:
+    def test_nonzero(self):
+        data = _build_time_of_day(14, 30)
+        fields = _decode_message(data)
+        assert fields[1] == [14]
+        assert fields[2] == [30]
+
+    def test_zero_hour(self):
+        # Hour 0 is omitted (if hours == 0, the field is skipped)
+        data = _build_time_of_day(0, 45)
+        fields = _decode_message(data)
+        assert 1 not in fields  # hours field omitted
+        assert fields[2] == [45]
+
+    def test_zero_minute(self):
+        data = _build_time_of_day(8, 0)
+        fields = _decode_message(data)
+        assert fields[1] == [8]
+        assert 2 not in fields  # minutes field omitted
+
+
+class TestBuildSetChargeTimerRequest:
+    def test_has_start_and_end(self):
+        data = _build_set_charge_timer_request(22, 0, 6, 30)
+        fields = _decode_message(data)
+        # Fields 1 and 2 should be length-delimited sub-messages
+        assert 1 in fields
+        assert 2 in fields
+
+
+# ---------------------------------------------------------------------------
+# Response parsers
+# ---------------------------------------------------------------------------
+
+
+class TestParseTargetSocResponse:
+    def test_empty_data(self):
+        result = _parse_target_soc_response(b"")
+        assert result["target_soc"] is None
+        assert result["enabled_values"] == []
+
+    def test_basic_response(self):
+        # Encode: field 1 = 80 (target_soc)
+        data = _encode_field_varint(1, 80)
+        result = _parse_target_soc_response(data)
+        assert result["target_soc"] == 80
+
+    def test_with_packed_enabled_values(self):
+        # Build a response with target_soc=80 and packed enabled_values
+        target = _encode_field_varint(1, 80)
+        # Pack values 50, 60, 70, 80, 90, 100 as length-delimited repeated varint
+        packed = b""
+        for v in [50, 60, 70, 80, 90, 100]:
+            packed += _encode_varint(v)
+        enabled = _encode_field_bytes(2, packed)
+        data = target + enabled
+        result = _parse_target_soc_response(data)
+        assert result["target_soc"] == 80
+        assert result["enabled_values"] == [50, 60, 70, 80, 90, 100]
+
+
+class TestParseChargeTimerResponse:
+    def test_empty_data(self):
+        result = _parse_charge_timer_response(b"")
+        assert result["start_hour"] is None
+        assert result["end_hour"] is None
+        assert result["is_departure_active"] is False
+
+    def test_with_times(self):
+        start = _build_time_of_day(22, 30)
+        end = _build_time_of_day(6, 0)
+        data = _encode_field_bytes(1, start) + _encode_field_bytes(2, end)
+        result = _parse_charge_timer_response(data)
+        assert result["start_hour"] == 22
+        assert result["start_min"] == 30
+        assert result["end_hour"] == 6
+        assert result["end_min"] == 0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,76 @@
+"""Tests for sensor value extraction functions."""
+
+from custom_components.polestar_soc.sensor import (
+    _battery_soc,
+    _charging_status,
+    _charging_time_remaining,
+    _odometer_km,
+)
+
+
+class TestBatterySoc:
+    def test_returns_percentage(self, sample_vehicle, sample_battery):
+        assert _battery_soc(sample_vehicle, sample_battery, None) == 72
+
+    def test_none_when_no_battery(self, sample_vehicle):
+        assert _battery_soc(sample_vehicle, None, None) is None
+
+    def test_none_when_missing_key(self, sample_vehicle):
+        assert _battery_soc(sample_vehicle, {"vin": "X"}, None) is None
+
+    def test_zero_percent(self, sample_vehicle):
+        battery = {"batteryChargeLevelPercentage": 0}
+        assert _battery_soc(sample_vehicle, battery, None) == 0
+
+    def test_full_charge(self, sample_vehicle):
+        battery = {"batteryChargeLevelPercentage": 100}
+        assert _battery_soc(sample_vehicle, battery, None) == 100
+
+
+class TestChargingStatus:
+    def test_known_status(self, sample_vehicle, sample_battery):
+        assert _charging_status(sample_vehicle, sample_battery, None) == "Charging"
+
+    def test_none_battery_returns_unknown(self, sample_vehicle):
+        assert _charging_status(sample_vehicle, None, None) == "Unknown"
+
+    def test_idle(self, sample_vehicle):
+        battery = {"chargingStatus": "CHARGING_STATUS_IDLE"}
+        assert _charging_status(sample_vehicle, battery, None) == "Idle"
+
+    def test_missing_status_key(self, sample_vehicle):
+        battery = {"vin": "X"}
+        result = _charging_status(sample_vehicle, battery, None)
+        assert result == "Unknown"
+
+
+class TestChargingTimeRemaining:
+    def test_returns_minutes(self, sample_vehicle, sample_battery):
+        assert _charging_time_remaining(sample_vehicle, sample_battery, None) == 95
+
+    def test_none_when_no_battery(self, sample_vehicle):
+        assert _charging_time_remaining(sample_vehicle, None, None) is None
+
+    def test_zero_minutes(self, sample_vehicle):
+        battery = {"estimatedChargingTimeToFullMinutes": 0}
+        assert _charging_time_remaining(sample_vehicle, battery, None) == 0
+
+
+class TestOdometerKm:
+    def test_converts_meters_to_km(self, sample_vehicle, sample_odometer):
+        result = _odometer_km(sample_vehicle, None, sample_odometer)
+        assert result == 12345.7  # 12345678 / 1000, rounded to 1 decimal
+
+    def test_none_when_no_odometer(self, sample_vehicle):
+        assert _odometer_km(sample_vehicle, None, None) is None
+
+    def test_none_when_missing_key(self, sample_vehicle):
+        assert _odometer_km(sample_vehicle, None, {"vin": "X"}) is None
+
+    def test_zero_meters(self, sample_vehicle):
+        odometer = {"odometerMeters": 0}
+        assert _odometer_km(sample_vehicle, None, odometer) == 0.0
+
+    def test_small_value(self, sample_vehicle):
+        odometer = {"odometerMeters": 500}
+        assert _odometer_km(sample_vehicle, None, odometer) == 0.5


### PR DESCRIPTION
Set up CI infrastructure for the Polestar SOC integration:
- GitHub Actions workflow with lint (ruff), test (pytest on 3.12/3.13), and validate (HACS + hassfest) jobs running on PRs and pushes to main
- 68 unit tests covering protobuf wire-format helpers, sensor value extraction, coordinator utilities, and constants
- pyproject.toml with pytest, ruff, and coverage configuration
- Auto-fix ruff import sorting and formatting on existing source files