### PR TITLE
Add climate status and estimated range sensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ build/
 htmlcov/
 .ruff_cache/
 .venv/
+research/
+plans/
+scripts/

--- a/custom_components/polestar_soc/__init__.py
+++ b/custom_components/polestar_soc/__init__.py
@@ -25,5 +25,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
+        coordinator: PolestarCoordinator = hass.data[DOMAIN].pop(entry.entry_id)
+        coordinator.close()
     return unload_ok

--- a/custom_components/polestar_soc/cep.py
+++ b/custom_components/polestar_soc/cep.py
@@ -1,0 +1,207 @@
+"""CEP (Volvo Connected Experience Platform) gRPC client.
+
+Communicates with the Volvo CEP gRPC API at cepmobtoken.eu.prod.c3.volvocars.com
+for reading vehicle state data (climate status, battery, etc.).
+
+Uses the same Polestar OAuth access token as the rest of the integration.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import grpc
+
+from .const import (
+    CEP_API_HOST,
+    CLIMATE_RUNNING_STATUS_MAP,
+    HEATING_INTENSITY_MAP,
+)
+from .proto import (
+    _decode_message,
+    _encode_field_bytes,
+    _get_double,
+    _get_int,
+    _get_submessage,
+    _identity_deserialize,
+    _identity_serialize,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# gRPC service method paths
+_METHOD_GET_CLIMATE = (
+    "/services.vehiclestates.parkingclimatization"
+    ".ParkingClimatizationService/GetLatestParkingClimatization"
+)
+_METHOD_GET_BATTERY = "/services.vehiclestates.battery.BatteryService/GetLatestBattery"
+
+
+# ---------------------------------------------------------------------------
+# Request builders
+# ---------------------------------------------------------------------------
+
+
+def _build_vin_request(vin: str) -> bytes:
+    """Build a request with VIN as field 2 (string)."""
+    return _encode_field_bytes(2, vin.encode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Response parsers
+# ---------------------------------------------------------------------------
+
+
+def _format_climate_status(value: int) -> str:
+    """Map climate running status enum to string."""
+    mapped = CLIMATE_RUNNING_STATUS_MAP.get(value)
+    if mapped is not None:
+        return mapped
+    _LOGGER.debug("Unknown climate running status: %d", value)
+    return f"Unknown ({value})"
+
+
+def _format_heating_intensity(value: int) -> str:
+    """Map heating intensity enum to string."""
+    mapped = HEATING_INTENSITY_MAP.get(value)
+    if mapped is not None:
+        return mapped
+    _LOGGER.debug("Unknown heating intensity: %d", value)
+    return f"Unknown ({value})"
+
+
+def _parse_climate_response(data: bytes) -> dict:
+    """Parse GetLatestParkingClimatization response.
+
+    Two-level decode: outer envelope has field 3 = state sub-message.
+    """
+    if not data:
+        return {
+            "status": None,
+            "driver_seat_heating": None,
+            "passenger_seat_heating": None,
+            "rear_left_seat_heating": None,
+            "rear_right_seat_heating": None,
+            "steering_wheel_heating": None,
+        }
+
+    outer = _decode_message(data)
+    state = _get_submessage(outer, 3)
+    if state is None:
+        return {
+            "status": None,
+            "driver_seat_heating": None,
+            "passenger_seat_heating": None,
+            "rear_left_seat_heating": None,
+            "rear_right_seat_heating": None,
+            "steering_wheel_heating": None,
+        }
+
+    return {
+        "status": _format_climate_status(_get_int(state, 2, 0)),
+        "driver_seat_heating": _format_heating_intensity(_get_int(state, 9, 0)),
+        "passenger_seat_heating": _format_heating_intensity(_get_int(state, 10, 0)),
+        "rear_left_seat_heating": _format_heating_intensity(_get_int(state, 11, 0)),
+        "rear_right_seat_heating": _format_heating_intensity(_get_int(state, 12, 0)),
+        "steering_wheel_heating": _format_heating_intensity(_get_int(state, 13, 0)),
+    }
+
+
+def _parse_battery_response(data: bytes) -> dict:
+    """Parse GetLatestBattery response.
+
+    Two-level decode: outer envelope has field 3 = battery state sub-message.
+    SOC and charging_power are IEEE 754 doubles (wire type 1 / fixed64).
+    """
+    if not data:
+        return {
+            "soc": None,
+            "estimated_range_km": None,
+            "charging_status": None,
+            "charging_power_kw": None,
+        }
+
+    outer = _decode_message(data)
+    state = _get_submessage(outer, 3)
+    if state is None:
+        return {
+            "soc": None,
+            "estimated_range_km": None,
+            "charging_status": None,
+            "charging_power_kw": None,
+        }
+
+    return {
+        "soc": _get_double(state, 2),
+        "estimated_range_km": _get_int(state, 4) or None,
+        "charging_status": _get_int(state, 6) or None,
+        "charging_power_kw": _get_double(state, 3),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CepClient
+# ---------------------------------------------------------------------------
+
+
+class CepClient:
+    """Client for the Volvo CEP gRPC API."""
+
+    def __init__(self, access_token: str) -> None:
+        self._access_token = access_token
+        self._channel: grpc.Channel | None = None
+
+    @property
+    def access_token(self) -> str:
+        return self._access_token
+
+    @access_token.setter
+    def access_token(self, value: str) -> None:
+        self._access_token = value
+
+    def _get_channel(self) -> grpc.Channel:
+        if self._channel is None:
+            credentials = grpc.ssl_channel_credentials()
+            self._channel = grpc.secure_channel(f"{CEP_API_HOST}:443", credentials)
+        return self._channel
+
+    def _metadata(self, vin: str) -> list[tuple[str, str]]:
+        return [
+            ("authorization", f"Bearer {self._access_token}"),
+            ("vin", vin),
+        ]
+
+    def close(self) -> None:
+        if self._channel is not None:
+            self._channel.close()
+            self._channel = None
+
+    def get_parking_climatization(self, vin: str) -> dict:
+        """Get current parking climatization state."""
+        channel = self._get_channel()
+        method = channel.unary_unary(
+            _METHOD_GET_CLIMATE,
+            request_serializer=_identity_serialize,
+            response_deserializer=_identity_deserialize,
+        )
+        try:
+            response = method(_build_vin_request(vin), metadata=self._metadata(vin), timeout=30)
+            return _parse_climate_response(response)
+        except grpc.RpcError as err:
+            _LOGGER.warning("CEP GetLatestParkingClimatization failed: %s", err)
+            raise
+
+    def get_battery(self, vin: str) -> dict:
+        """Get current battery state."""
+        channel = self._get_channel()
+        method = channel.unary_unary(
+            _METHOD_GET_BATTERY,
+            request_serializer=_identity_serialize,
+            response_deserializer=_identity_deserialize,
+        )
+        try:
+            response = method(_build_vin_request(vin), metadata=self._metadata(vin), timeout=30)
+            return _parse_battery_response(response)
+        except grpc.RpcError as err:
+            _LOGGER.warning("CEP GetLatestBattery failed: %s", err)
+            raise

--- a/custom_components/polestar_soc/const.py
+++ b/custom_components/polestar_soc/const.py
@@ -19,6 +19,9 @@ API_URL = "https://pc-api.polestar.com/eu-north-1/mystar-v2/"
 # PCCS gRPC API
 PCCS_API_HOST = "api.pccs-prod.plstr.io"
 
+# Volvo CEP gRPC API (vehicle state reads)
+CEP_API_HOST = "cepmobtoken.eu.prod.c3.volvocars.com"
+
 QUERY_GET_CARS = """
 query getCars {
   getConsumerCarsV2 {
@@ -58,4 +61,24 @@ CHARGING_STATUS_MAP = {
     "CHARGING_STATUS_FAULT": "Fault",
     "CHARGING_STATUS_UNSPECIFIED": "Unknown",
     "CHARGING_STATUS_SCHEDULED": "Scheduled",
+}
+
+# Climate running status enum (field 2 of ParkingClimatizationState)
+CLIMATE_RUNNING_STATUS_MAP: dict[int, str] = {
+    0: "Unknown",
+    1: "Starting",
+    2: "Off",
+    3: "Pre-conditioning",
+    4: "Pre-conditioning (external power)",
+    5: "Pre-cleaning",
+    6: "Pre-conditioning and cleaning",
+    7: "Residual heat",
+}
+
+# Heating intensity enum (seat heaters + steering wheel)
+HEATING_INTENSITY_MAP: dict[int, str] = {
+    0: "Off",
+    1: "Low",
+    2: "Medium",
+    3: "High",
 }

--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -15,6 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .cep import CepClient
 from .const import (
     API_URL,
     CHARGING_STATUS_MAP,
@@ -221,6 +222,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
         self.api.access_token = entry.data.get("access_token")
         self.api.refresh_token = entry.data.get("refresh_token")
         self.pccs = PccsClient(self.api.access_token or "")
+        self.cep = CepClient(self.api.access_token or "")
         self._email: str = entry.data["email"]
         self._password: str = entry.data["password"]
 
@@ -278,6 +280,8 @@ class PolestarCoordinator(DataUpdateCoordinator):
                     "odometer": {},
                     "target_soc": {},
                     "charge_timer": {},
+                    "climate": {},
+                    "cep_battery": {},
                 }
 
             vins = [v["vin"] for v in vehicles]
@@ -306,12 +310,27 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 except Exception:
                     _LOGGER.debug("Failed to fetch PCCS charge timer for %s", vin)
 
+            # Fetch CEP data (climate status + battery) per VIN
+            climate_by_vin: dict = {}
+            cep_battery_by_vin: dict = {}
+            for vin in vins:
+                try:
+                    climate_by_vin[vin] = self.cep.get_parking_climatization(vin)
+                except Exception:
+                    _LOGGER.debug("Failed to fetch CEP climate for %s", vin)
+                try:
+                    cep_battery_by_vin[vin] = self.cep.get_battery(vin)
+                except Exception:
+                    _LOGGER.debug("Failed to fetch CEP battery for %s", vin)
+
             return {
                 "vehicles": vehicles,
                 "battery": battery_by_vin,
                 "odometer": odometer_by_vin,
                 "target_soc": target_soc_by_vin,
                 "charge_timer": charge_timer_by_vin,
+                "climate": climate_by_vin,
+                "cep_battery": cep_battery_by_vin,
             }
 
         return await self.hass.async_add_executor_job(_do_fetch)
@@ -326,8 +345,14 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 "refresh_token": self.api.refresh_token,
             },
         )
-        # Keep PCCS client token in sync
+        # Keep gRPC client tokens in sync
         self.pccs.access_token = self.api.access_token or ""
+        self.cep.access_token = self.api.access_token or ""
+
+    def close(self) -> None:
+        """Close gRPC channels."""
+        self.pccs.close()
+        self.cep.close()
 
     @staticmethod
     def format_charging_status(status: str | None) -> str:

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -10,11 +10,21 @@ with manual protobuf wire-format encoding/decoding.
 from __future__ import annotations
 
 import logging
-import struct
 
 import grpc
 
 from .const import PCCS_API_HOST
+from .proto import (
+    _decode_message,
+    _decode_varint,
+    _encode_field_bytes,
+    _encode_field_varint,
+    _get_bool,
+    _get_int,
+    _get_submessage,
+    _identity_deserialize,
+    _identity_serialize,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,105 +39,9 @@ _METHOD_SET_CHARGE_TIMER = f"{_SVC_CHARGE_TIMER}/SetGlobalChargeTimer"
 
 
 # ---------------------------------------------------------------------------
-# Minimal protobuf wire-format helpers
-# ---------------------------------------------------------------------------
-# Wire types: 0=varint, 2=length-delimited
-
-
-def _encode_varint(value: int) -> bytes:
-    """Encode an integer as a protobuf varint."""
-    pieces = []
-    while value > 0x7F:
-        pieces.append((value & 0x7F) | 0x80)
-        value >>= 7
-    pieces.append(value & 0x7F)
-    return bytes(pieces)
-
-
-def _encode_field_varint(field_number: int, value: int) -> bytes:
-    """Encode a varint field (tag + value)."""
-    tag = (field_number << 3) | 0  # wire type 0
-    return _encode_varint(tag) + _encode_varint(value)
-
-
-def _encode_field_bytes(field_number: int, data: bytes) -> bytes:
-    """Encode a length-delimited field (tag + length + data)."""
-    tag = (field_number << 3) | 2  # wire type 2
-    return _encode_varint(tag) + _encode_varint(len(data)) + data
-
-
-def _decode_varint(data: bytes, pos: int) -> tuple[int, int]:
-    """Decode a varint starting at pos, return (value, new_pos)."""
-    result = 0
-    shift = 0
-    while pos < len(data):
-        b = data[pos]
-        result |= (b & 0x7F) << shift
-        pos += 1
-        if (b & 0x80) == 0:
-            return result, pos
-        shift += 7
-    raise ValueError("Truncated varint")
-
-
-def _decode_message(data: bytes) -> dict[int, list]:
-    """Decode a protobuf message into {field_number: [values]}.
-
-    Returns raw values: ints for varint fields, bytes for length-delimited.
-    Fixed32/64 fields are also handled.
-    """
-    fields: dict[int, list] = {}
-    pos = 0
-    while pos < len(data):
-        tag, pos = _decode_varint(data, pos)
-        field_number = tag >> 3
-        wire_type = tag & 0x07
-
-        if wire_type == 0:  # varint
-            value, pos = _decode_varint(data, pos)
-        elif wire_type == 2:  # length-delimited
-            length, pos = _decode_varint(data, pos)
-            value = data[pos : pos + length]
-            pos += length
-        elif wire_type == 5:  # fixed32
-            value = struct.unpack_from("<I", data, pos)[0]
-            pos += 4
-        elif wire_type == 1:  # fixed64
-            value = struct.unpack_from("<Q", data, pos)[0]
-            pos += 8
-        else:
-            raise ValueError(f"Unsupported wire type {wire_type}")
-
-        fields.setdefault(field_number, []).append(value)
-
-    return fields
-
-
-def _get_int(fields: dict[int, list], field_number: int, default: int = 0) -> int:
-    """Extract an integer value from decoded fields."""
-    vals = fields.get(field_number)
-    if vals:
-        return vals[0]
-    return default
-
-
-def _get_bool(fields: dict[int, list], field_number: int) -> bool:
-    """Extract a boolean value from decoded fields."""
-    return bool(_get_int(fields, field_number, 0))
-
-
-def _get_submessage(fields: dict[int, list], field_number: int) -> dict[int, list] | None:
-    """Extract and decode a sub-message from decoded fields."""
-    vals = fields.get(field_number)
-    if vals and isinstance(vals[0], (bytes, bytearray)):
-        return _decode_message(vals[0])
-    return None
-
-
-# ---------------------------------------------------------------------------
 # Protobuf message builders
 # ---------------------------------------------------------------------------
-# Field numbers based on APK-decompiled message definitions.
+# Protobuf field numbers for each message type.
 #
 # TargetSoc message:
 #   1: targetSoc (int32)
@@ -236,19 +150,6 @@ def _parse_charge_timer_response(data: bytes) -> dict:
         "is_departure_active": _get_bool(fields, 5),
         "is_location_timer_active": _get_bool(fields, 6),
     }
-
-
-# ---------------------------------------------------------------------------
-# Raw serializer/deserializer for grpc channel methods
-# ---------------------------------------------------------------------------
-
-
-def _identity_serialize(data: bytes) -> bytes:
-    return data
-
-
-def _identity_deserialize(data: bytes) -> bytes:
-    return data
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/polestar_soc/proto.py
+++ b/custom_components/polestar_soc/proto.py
@@ -1,0 +1,143 @@
+"""Minimal protobuf wire-format helpers.
+
+Shared encoding/decoding utilities for gRPC clients that communicate
+without compiled .proto stubs.  Both pccs.py and cep.py import from here.
+
+Wire types: 0=varint, 1=fixed64, 2=length-delimited, 5=fixed32
+"""
+
+from __future__ import annotations
+
+import struct
+
+# ---------------------------------------------------------------------------
+# Encoding
+# ---------------------------------------------------------------------------
+
+
+def _encode_varint(value: int) -> bytes:
+    """Encode an integer as a protobuf varint."""
+    pieces = []
+    while value > 0x7F:
+        pieces.append((value & 0x7F) | 0x80)
+        value >>= 7
+    pieces.append(value & 0x7F)
+    return bytes(pieces)
+
+
+def _encode_field_varint(field_number: int, value: int) -> bytes:
+    """Encode a varint field (tag + value)."""
+    tag = (field_number << 3) | 0  # wire type 0
+    return _encode_varint(tag) + _encode_varint(value)
+
+
+def _encode_field_bytes(field_number: int, data: bytes) -> bytes:
+    """Encode a length-delimited field (tag + length + data)."""
+    tag = (field_number << 3) | 2  # wire type 2
+    return _encode_varint(tag) + _encode_varint(len(data)) + data
+
+
+# ---------------------------------------------------------------------------
+# Decoding
+# ---------------------------------------------------------------------------
+
+
+def _decode_varint(data: bytes, pos: int) -> tuple[int, int]:
+    """Decode a varint starting at pos, return (value, new_pos)."""
+    result = 0
+    shift = 0
+    while pos < len(data):
+        b = data[pos]
+        result |= (b & 0x7F) << shift
+        pos += 1
+        if (b & 0x80) == 0:
+            return result, pos
+        shift += 7
+    raise ValueError("Truncated varint")
+
+
+def _decode_message(data: bytes) -> dict[int, list]:
+    """Decode a protobuf message into {field_number: [values]}.
+
+    Returns raw values: ints for varint fields, bytes for length-delimited.
+    Fixed32/64 fields are also handled.
+    """
+    fields: dict[int, list] = {}
+    pos = 0
+    while pos < len(data):
+        tag, pos = _decode_varint(data, pos)
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+
+        if wire_type == 0:  # varint
+            value, pos = _decode_varint(data, pos)
+        elif wire_type == 2:  # length-delimited
+            length, pos = _decode_varint(data, pos)
+            value = data[pos : pos + length]
+            pos += length
+        elif wire_type == 5:  # fixed32
+            value = struct.unpack_from("<I", data, pos)[0]
+            pos += 4
+        elif wire_type == 1:  # fixed64
+            value = struct.unpack_from("<Q", data, pos)[0]
+            pos += 8
+        else:
+            raise ValueError(f"Unsupported wire type {wire_type}")
+
+        fields.setdefault(field_number, []).append(value)
+
+    return fields
+
+
+# ---------------------------------------------------------------------------
+# Field extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_int(fields: dict[int, list], field_number: int, default: int = 0) -> int:
+    """Extract an integer value from decoded fields."""
+    vals = fields.get(field_number)
+    if vals:
+        return vals[0]
+    return default
+
+
+def _get_bool(fields: dict[int, list], field_number: int) -> bool:
+    """Extract a boolean value from decoded fields."""
+    return bool(_get_int(fields, field_number, 0))
+
+
+def _get_submessage(fields: dict[int, list], field_number: int) -> dict[int, list] | None:
+    """Extract and decode a sub-message from decoded fields."""
+    vals = fields.get(field_number)
+    if vals and isinstance(vals[0], (bytes, bytearray)):
+        return _decode_message(vals[0])
+    return None
+
+
+def _get_double(fields: dict[int, list], field_number: int) -> float | None:
+    """Extract a double (IEEE 754) from a fixed64 field.
+
+    _decode_message stores wire type 1 as uint64.  This helper reinterprets
+    the raw bits as a double-precision float.
+    """
+    vals = fields.get(field_number)
+    if not vals:
+        return None
+    raw = vals[0]
+    if isinstance(raw, int):
+        return struct.unpack("<d", struct.pack("<Q", raw))[0]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Raw serializer/deserializer for grpc channel methods
+# ---------------------------------------------------------------------------
+
+
+def _identity_serialize(data: bytes) -> bytes:
+    return data
+
+
+def _identity_deserialize(data: bytes) -> bytes:
+    return data

--- a/custom_components/polestar_soc/sensor.py
+++ b/custom_components/polestar_soc/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import CLIMATE_RUNNING_STATUS_MAP, DOMAIN, HEATING_INTENSITY_MAP
 from .coordinator import PolestarCoordinator
 
 
@@ -26,30 +26,37 @@ from .coordinator import PolestarCoordinator
 class PolestarSensorDescription(SensorEntityDescription):
     """Describe a Polestar sensor."""
 
-    value_fn: Callable[[dict, dict | None, dict | None], object]
+    value_fn: Callable[[dict, str], object]
 
 
-def _battery_soc(vehicle: dict, battery: dict | None, odometer: dict | None) -> int | None:
+# ---------------------------------------------------------------------------
+# Value functions — each takes (coordinator_data, vin)
+# ---------------------------------------------------------------------------
+
+
+def _battery_soc(data: dict, vin: str) -> int | None:
+    battery = data.get("battery", {}).get(vin)
     if battery is None:
         return None
     return battery.get("batteryChargeLevelPercentage")
 
 
-def _charging_status(vehicle: dict, battery: dict | None, odometer: dict | None) -> str:
+def _charging_status(data: dict, vin: str) -> str:
+    battery = data.get("battery", {}).get(vin)
     if battery is None:
         return "Unknown"
     return PolestarCoordinator.format_charging_status(battery.get("chargingStatus"))
 
 
-def _charging_time_remaining(
-    vehicle: dict, battery: dict | None, odometer: dict | None
-) -> int | None:
+def _charging_time_remaining(data: dict, vin: str) -> int | None:
+    battery = data.get("battery", {}).get(vin)
     if battery is None:
         return None
     return battery.get("estimatedChargingTimeToFullMinutes")
 
 
-def _odometer_km(vehicle: dict, battery: dict | None, odometer: dict | None) -> float | None:
+def _odometer_km(data: dict, vin: str) -> float | None:
+    odometer = data.get("odometer", {}).get(vin)
     if odometer is None:
         return None
     meters = odometer.get("odometerMeters")
@@ -57,6 +64,36 @@ def _odometer_km(vehicle: dict, battery: dict | None, odometer: dict | None) -> 
         return None
     return round(meters / 1000, 1)
 
+
+def _climate_status(data: dict, vin: str) -> str | None:
+    climate = data.get("climate", {}).get(vin)
+    if climate is None:
+        return None
+    return climate.get("status")
+
+
+def _climate_heating(key: str) -> Callable[[dict, str], str | None]:
+    """Create a value_fn for a heating intensity sensor."""
+
+    def _value_fn(data: dict, vin: str) -> str | None:
+        climate = data.get("climate", {}).get(vin)
+        if climate is None:
+            return None
+        return climate.get(key)
+
+    return _value_fn
+
+
+def _estimated_range(data: dict, vin: str) -> int | None:
+    cep_battery = data.get("cep_battery", {}).get(vin)
+    if cep_battery is None:
+        return None
+    return cep_battery.get("estimated_range_km")
+
+
+# Options lists for ENUM sensors
+_CLIMATE_STATUS_OPTIONS = list(CLIMATE_RUNNING_STATUS_MAP.values())
+_HEATING_INTENSITY_OPTIONS = list(HEATING_INTENSITY_MAP.values())
 
 SENSOR_DESCRIPTIONS: tuple[PolestarSensorDescription, ...] = (
     PolestarSensorDescription(
@@ -87,6 +124,56 @@ SENSOR_DESCRIPTIONS: tuple[PolestarSensorDescription, ...] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=_odometer_km,
+    ),
+    PolestarSensorDescription(
+        key="climate_status",
+        translation_key="climate_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=_CLIMATE_STATUS_OPTIONS,
+        value_fn=_climate_status,
+    ),
+    PolestarSensorDescription(
+        key="driver_seat_heating",
+        translation_key="driver_seat_heating",
+        device_class=SensorDeviceClass.ENUM,
+        options=_HEATING_INTENSITY_OPTIONS,
+        value_fn=_climate_heating("driver_seat_heating"),
+    ),
+    PolestarSensorDescription(
+        key="passenger_seat_heating",
+        translation_key="passenger_seat_heating",
+        device_class=SensorDeviceClass.ENUM,
+        options=_HEATING_INTENSITY_OPTIONS,
+        value_fn=_climate_heating("passenger_seat_heating"),
+    ),
+    PolestarSensorDescription(
+        key="rear_left_seat_heating",
+        translation_key="rear_left_seat_heating",
+        device_class=SensorDeviceClass.ENUM,
+        options=_HEATING_INTENSITY_OPTIONS,
+        value_fn=_climate_heating("rear_left_seat_heating"),
+    ),
+    PolestarSensorDescription(
+        key="rear_right_seat_heating",
+        translation_key="rear_right_seat_heating",
+        device_class=SensorDeviceClass.ENUM,
+        options=_HEATING_INTENSITY_OPTIONS,
+        value_fn=_climate_heating("rear_right_seat_heating"),
+    ),
+    PolestarSensorDescription(
+        key="steering_wheel_heating",
+        translation_key="steering_wheel_heating",
+        device_class=SensorDeviceClass.ENUM,
+        options=_HEATING_INTENSITY_OPTIONS,
+        value_fn=_climate_heating("steering_wheel_heating"),
+    ),
+    PolestarSensorDescription(
+        key="estimated_range",
+        translation_key="estimated_range",
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_estimated_range,
     ),
 )
 
@@ -148,12 +235,4 @@ class PolestarSensor(CoordinatorEntity[PolestarCoordinator], SensorEntity):
         data = self.coordinator.data
         if not data:
             return None
-        battery = data.get("battery", {}).get(self._vin)
-        odometer = data.get("odometer", {}).get(self._vin)
-        # Find current vehicle info
-        vehicle = {}
-        for v in data.get("vehicles", []):
-            if v["vin"] == self._vin:
-                vehicle = v
-                break
-        return self.entity_description.value_fn(vehicle, battery, odometer)
+        return self.entity_description.value_fn(data, self._vin)

--- a/custom_components/polestar_soc/strings.json
+++ b/custom_components/polestar_soc/strings.json
@@ -41,6 +41,27 @@
       },
       "odometer": {
         "name": "Odometer"
+      },
+      "climate_status": {
+        "name": "Climate status"
+      },
+      "driver_seat_heating": {
+        "name": "Driver seat heating"
+      },
+      "passenger_seat_heating": {
+        "name": "Passenger seat heating"
+      },
+      "rear_left_seat_heating": {
+        "name": "Rear left seat heating"
+      },
+      "rear_right_seat_heating": {
+        "name": "Rear right seat heating"
+      },
+      "steering_wheel_heating": {
+        "name": "Steering wheel heating"
+      },
+      "estimated_range": {
+        "name": "Estimated range"
       }
     },
     "number": {

--- a/custom_components/polestar_soc/translations/en.json
+++ b/custom_components/polestar_soc/translations/en.json
@@ -41,6 +41,27 @@
       },
       "odometer": {
         "name": "Odometer"
+      },
+      "climate_status": {
+        "name": "Climate status"
+      },
+      "driver_seat_heating": {
+        "name": "Driver seat heating"
+      },
+      "passenger_seat_heating": {
+        "name": "Passenger seat heating"
+      },
+      "rear_left_seat_heating": {
+        "name": "Rear left seat heating"
+      },
+      "rear_right_seat_heating": {
+        "name": "Rear right seat heating"
+      },
+      "steering_wheel_heating": {
+        "name": "Steering wheel heating"
+      },
+      "estimated_range": {
+        "name": "Estimated range"
       }
     },
     "number": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,3 +39,47 @@ def sample_odometer():
         "vin": "YSMYKEAE1RB000001",
         "odometerMeters": 12345678,
     }
+
+
+@pytest.fixture
+def sample_climate():
+    """Return a sample climate status dict (as returned by CepClient)."""
+    return {
+        "status": "Off",
+        "driver_seat_heating": "Off",
+        "passenger_seat_heating": "Off",
+        "rear_left_seat_heating": "Off",
+        "rear_right_seat_heating": "Off",
+        "steering_wheel_heating": "Off",
+    }
+
+
+@pytest.fixture
+def sample_cep_battery():
+    """Return a sample CEP battery dict (as returned by CepClient)."""
+    return {
+        "soc": 76.0,
+        "estimated_range_km": 230,
+        "charging_status": 2,
+        "charging_power_kw": 2.9,
+    }
+
+
+VIN = "YSMYKEAE1RB000001"
+
+
+@pytest.fixture
+def sample_coordinator_data(
+    sample_vehicle, sample_battery, sample_odometer, sample_climate, sample_cep_battery
+):
+    """Return a full coordinator data dict combining all sources."""
+    vin = sample_vehicle["vin"]
+    return {
+        "vehicles": [sample_vehicle],
+        "battery": {vin: sample_battery},
+        "odometer": {vin: sample_odometer},
+        "target_soc": {},
+        "charge_timer": {},
+        "climate": {vin: sample_climate},
+        "cep_battery": {vin: sample_cep_battery},
+    }

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -1,0 +1,141 @@
+"""Tests for CEP gRPC client protobuf parsers and request builder."""
+
+import struct
+
+import pytest
+
+from custom_components.polestar_soc.cep import (
+    _build_vin_request,
+    _format_climate_status,
+    _format_heating_intensity,
+    _parse_battery_response,
+    _parse_climate_response,
+)
+from custom_components.polestar_soc.proto import (
+    _decode_message,
+    _encode_field_bytes,
+    _get_submessage,
+)
+
+# Synthetic test payloads built with a fake VIN.
+# ParkingClimatization: climate off, all seat heaters off
+CLIMATE_PAYLOAD = bytes.fromhex(
+    "121159534d594b4541453152423030303030311a1e0a0c08b0dcb6cd0610808c8d9e02"
+    "10021800300348005000580060006800"
+)
+
+# Battery: SOC=76.0, charging_power=2.9, range=230, charging_status=2
+BATTERY_PAYLOAD = bytes.fromhex(
+    "121159534d594b4541453152423030303030311a2c0a0c08b0dcb6cd0610808c8d9e02"
+    "11000000000000534019333333333333074020e601280030023802408c01"
+)
+
+TEST_VIN = "YSMYKEAE1RB000001"
+
+
+class TestBuildVinRequest:
+    def test_produces_field_2_string(self):
+        result = _build_vin_request(TEST_VIN)
+        fields = _decode_message(result)
+        # Field 2 should be the VIN as bytes
+        assert 2 in fields
+        assert fields[2][0] == TEST_VIN.encode("utf-8")
+
+    def test_roundtrip_vin(self):
+        result = _build_vin_request(TEST_VIN)
+        # Should be: tag(field 2, wire type 2) + varint(len) + VIN bytes
+        expected = _encode_field_bytes(2, TEST_VIN.encode("utf-8"))
+        assert result == expected
+
+
+class TestParseClimateResponse:
+    def test_parsed_response(self):
+        result = _parse_climate_response(CLIMATE_PAYLOAD)
+        assert result["status"] == "Off"
+        assert result["driver_seat_heating"] == "Off"
+        assert result["passenger_seat_heating"] == "Off"
+        assert result["rear_left_seat_heating"] == "Off"
+        assert result["rear_right_seat_heating"] == "Off"
+        assert result["steering_wheel_heating"] == "Off"
+
+    def test_empty_response(self):
+        result = _parse_climate_response(b"")
+        assert result["status"] is None
+        assert result["driver_seat_heating"] is None
+
+    def test_two_level_decode(self):
+        """Verify outer envelope has field 2=VIN and field 3=state."""
+        outer = _decode_message(CLIMATE_PAYLOAD)
+        # Field 2 should be VIN
+        assert outer[2][0] == TEST_VIN.encode("utf-8")
+        # Field 3 should be a sub-message (bytes)
+        assert isinstance(outer[3][0], (bytes, bytearray))
+        # Inner state should have field 2 (running status)
+        state = _get_submessage(outer, 3)
+        assert state is not None
+        assert 2 in state  # running status field
+
+    def test_missing_state_submessage(self):
+        """Response with VIN but no field 3 returns None values."""
+        # Just a VIN field with no state sub-message
+        data = _encode_field_bytes(2, TEST_VIN.encode("utf-8"))
+        result = _parse_climate_response(data)
+        assert result["status"] is None
+        assert result["driver_seat_heating"] is None
+
+
+class TestParseBatteryResponse:
+    def test_parsed_response(self):
+        result = _parse_battery_response(BATTERY_PAYLOAD)
+        assert result["soc"] == pytest.approx(76.0)
+        assert result["estimated_range_km"] == 230
+        assert result["charging_power_kw"] == pytest.approx(2.9, abs=0.1)
+        assert result["charging_status"] == 2
+
+    def test_empty_response(self):
+        result = _parse_battery_response(b"")
+        assert result["soc"] is None
+        assert result["estimated_range_km"] is None
+        assert result["charging_status"] is None
+        assert result["charging_power_kw"] is None
+
+    def test_two_level_decode(self):
+        """Verify outer envelope field 3 contains battery state."""
+        outer = _decode_message(BATTERY_PAYLOAD)
+        assert outer[2][0] == TEST_VIN.encode("utf-8")
+        state = _get_submessage(outer, 3)
+        assert state is not None
+        # Field 2 is SOC (fixed64, stored as uint64)
+        assert 2 in state
+        raw_soc = state[2][0]
+        soc = struct.unpack("<d", struct.pack("<Q", raw_soc))[0]
+        assert soc == pytest.approx(76.0)
+
+    def test_missing_state_submessage(self):
+        data = _encode_field_bytes(2, TEST_VIN.encode("utf-8"))
+        result = _parse_battery_response(data)
+        assert result["soc"] is None
+        assert result["estimated_range_km"] is None
+
+
+class TestFormatClimateStatus:
+    def test_known_values(self):
+        assert _format_climate_status(0) == "Unknown"
+        assert _format_climate_status(2) == "Off"
+        assert _format_climate_status(3) == "Pre-conditioning"
+
+    def test_unknown_value(self):
+        result = _format_climate_status(99)
+        assert result == "Unknown (99)"
+
+
+class TestFormatHeatingIntensity:
+    def test_known_values(self):
+        assert _format_heating_intensity(0) == "Off"
+        assert _format_heating_intensity(1) == "Low"
+        assert _format_heating_intensity(2) == "Medium"
+        assert _format_heating_intensity(3) == "High"
+
+    def test_unknown_value(self):
+        result = _format_heating_intensity(42)
+        assert result == "Unknown (42)"

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -6,6 +6,10 @@ from custom_components.polestar_soc.pccs import (
     _build_set_charge_timer_request,
     _build_set_target_soc_request,
     _build_time_of_day,
+    _parse_charge_timer_response,
+    _parse_target_soc_response,
+)
+from custom_components.polestar_soc.proto import (
     _decode_message,
     _decode_varint,
     _encode_field_bytes,
@@ -14,8 +18,6 @@ from custom_components.polestar_soc.pccs import (
     _get_bool,
     _get_int,
     _get_submessage,
-    _parse_charge_timer_response,
-    _parse_target_soc_response,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -4,73 +4,170 @@ from custom_components.polestar_soc.sensor import (
     _battery_soc,
     _charging_status,
     _charging_time_remaining,
+    _climate_heating,
+    _climate_status,
+    _estimated_range,
     _odometer_km,
 )
 
+VIN = "YSMYKEAE1RB000001"
+
+
+# ---------------------------------------------------------------------------
+# Existing sensors (updated signature: data, vin)
+# ---------------------------------------------------------------------------
+
 
 class TestBatterySoc:
-    def test_returns_percentage(self, sample_vehicle, sample_battery):
-        assert _battery_soc(sample_vehicle, sample_battery, None) == 72
+    def test_returns_percentage(self, sample_coordinator_data):
+        assert _battery_soc(sample_coordinator_data, VIN) == 72
 
-    def test_none_when_no_battery(self, sample_vehicle):
-        assert _battery_soc(sample_vehicle, None, None) is None
+    def test_none_when_no_battery(self, sample_coordinator_data):
+        sample_coordinator_data["battery"] = {}
+        assert _battery_soc(sample_coordinator_data, VIN) is None
 
-    def test_none_when_missing_key(self, sample_vehicle):
-        assert _battery_soc(sample_vehicle, {"vin": "X"}, None) is None
+    def test_none_when_missing_key(self):
+        data = {"battery": {VIN: {"vin": "X"}}}
+        assert _battery_soc(data, VIN) is None
 
-    def test_zero_percent(self, sample_vehicle):
-        battery = {"batteryChargeLevelPercentage": 0}
-        assert _battery_soc(sample_vehicle, battery, None) == 0
+    def test_zero_percent(self):
+        data = {"battery": {VIN: {"batteryChargeLevelPercentage": 0}}}
+        assert _battery_soc(data, VIN) == 0
 
-    def test_full_charge(self, sample_vehicle):
-        battery = {"batteryChargeLevelPercentage": 100}
-        assert _battery_soc(sample_vehicle, battery, None) == 100
+    def test_full_charge(self):
+        data = {"battery": {VIN: {"batteryChargeLevelPercentage": 100}}}
+        assert _battery_soc(data, VIN) == 100
 
 
 class TestChargingStatus:
-    def test_known_status(self, sample_vehicle, sample_battery):
-        assert _charging_status(sample_vehicle, sample_battery, None) == "Charging"
+    def test_known_status(self, sample_coordinator_data):
+        assert _charging_status(sample_coordinator_data, VIN) == "Charging"
 
-    def test_none_battery_returns_unknown(self, sample_vehicle):
-        assert _charging_status(sample_vehicle, None, None) == "Unknown"
+    def test_none_battery_returns_unknown(self):
+        data = {"battery": {}}
+        assert _charging_status(data, VIN) == "Unknown"
 
-    def test_idle(self, sample_vehicle):
-        battery = {"chargingStatus": "CHARGING_STATUS_IDLE"}
-        assert _charging_status(sample_vehicle, battery, None) == "Idle"
+    def test_idle(self):
+        data = {"battery": {VIN: {"chargingStatus": "CHARGING_STATUS_IDLE"}}}
+        assert _charging_status(data, VIN) == "Idle"
 
-    def test_missing_status_key(self, sample_vehicle):
-        battery = {"vin": "X"}
-        result = _charging_status(sample_vehicle, battery, None)
+    def test_missing_status_key(self):
+        data = {"battery": {VIN: {"vin": "X"}}}
+        result = _charging_status(data, VIN)
         assert result == "Unknown"
 
 
 class TestChargingTimeRemaining:
-    def test_returns_minutes(self, sample_vehicle, sample_battery):
-        assert _charging_time_remaining(sample_vehicle, sample_battery, None) == 95
+    def test_returns_minutes(self, sample_coordinator_data):
+        assert _charging_time_remaining(sample_coordinator_data, VIN) == 95
 
-    def test_none_when_no_battery(self, sample_vehicle):
-        assert _charging_time_remaining(sample_vehicle, None, None) is None
+    def test_none_when_no_battery(self):
+        data = {"battery": {}}
+        assert _charging_time_remaining(data, VIN) is None
 
-    def test_zero_minutes(self, sample_vehicle):
-        battery = {"estimatedChargingTimeToFullMinutes": 0}
-        assert _charging_time_remaining(sample_vehicle, battery, None) == 0
+    def test_zero_minutes(self):
+        data = {"battery": {VIN: {"estimatedChargingTimeToFullMinutes": 0}}}
+        assert _charging_time_remaining(data, VIN) == 0
 
 
 class TestOdometerKm:
-    def test_converts_meters_to_km(self, sample_vehicle, sample_odometer):
-        result = _odometer_km(sample_vehicle, None, sample_odometer)
+    def test_converts_meters_to_km(self, sample_coordinator_data):
+        result = _odometer_km(sample_coordinator_data, VIN)
         assert result == 12345.7  # 12345678 / 1000, rounded to 1 decimal
 
-    def test_none_when_no_odometer(self, sample_vehicle):
-        assert _odometer_km(sample_vehicle, None, None) is None
+    def test_none_when_no_odometer(self):
+        data = {"odometer": {}}
+        assert _odometer_km(data, VIN) is None
 
-    def test_none_when_missing_key(self, sample_vehicle):
-        assert _odometer_km(sample_vehicle, None, {"vin": "X"}) is None
+    def test_none_when_missing_key(self):
+        data = {"odometer": {VIN: {"vin": "X"}}}
+        assert _odometer_km(data, VIN) is None
 
-    def test_zero_meters(self, sample_vehicle):
-        odometer = {"odometerMeters": 0}
-        assert _odometer_km(sample_vehicle, None, odometer) == 0.0
+    def test_zero_meters(self):
+        data = {"odometer": {VIN: {"odometerMeters": 0}}}
+        assert _odometer_km(data, VIN) == 0.0
 
-    def test_small_value(self, sample_vehicle):
-        odometer = {"odometerMeters": 500}
-        assert _odometer_km(sample_vehicle, None, odometer) == 0.5
+    def test_small_value(self):
+        data = {"odometer": {VIN: {"odometerMeters": 500}}}
+        assert _odometer_km(data, VIN) == 0.5
+
+
+# ---------------------------------------------------------------------------
+# New climate sensors
+# ---------------------------------------------------------------------------
+
+
+class TestClimateStatus:
+    def test_returns_status(self, sample_coordinator_data):
+        assert _climate_status(sample_coordinator_data, VIN) == "Off"
+
+    def test_none_when_no_climate(self):
+        data = {"climate": {}}
+        assert _climate_status(data, VIN) is None
+
+    def test_none_when_empty_data(self):
+        assert _climate_status({}, VIN) is None
+
+    def test_active_status(self):
+        data = {"climate": {VIN: {"status": "Pre-conditioning"}}}
+        assert _climate_status(data, VIN) == "Pre-conditioning"
+
+
+class TestDriverSeatHeating:
+    def test_returns_level(self, sample_coordinator_data):
+        fn = _climate_heating("driver_seat_heating")
+        assert fn(sample_coordinator_data, VIN) == "Off"
+
+    def test_none_when_no_climate(self):
+        fn = _climate_heating("driver_seat_heating")
+        data = {"climate": {}}
+        assert fn(data, VIN) is None
+
+    def test_heating_active(self):
+        fn = _climate_heating("driver_seat_heating")
+        data = {"climate": {VIN: {"driver_seat_heating": "High"}}}
+        assert fn(data, VIN) == "High"
+
+
+class TestPassengerSeatHeating:
+    def test_returns_level(self, sample_coordinator_data):
+        fn = _climate_heating("passenger_seat_heating")
+        assert fn(sample_coordinator_data, VIN) == "Off"
+
+
+class TestRearLeftSeatHeating:
+    def test_returns_level(self, sample_coordinator_data):
+        fn = _climate_heating("rear_left_seat_heating")
+        assert fn(sample_coordinator_data, VIN) == "Off"
+
+
+class TestRearRightSeatHeating:
+    def test_returns_level(self, sample_coordinator_data):
+        fn = _climate_heating("rear_right_seat_heating")
+        assert fn(sample_coordinator_data, VIN) == "Off"
+
+
+class TestSteeringWheelHeating:
+    def test_returns_level(self, sample_coordinator_data):
+        fn = _climate_heating("steering_wheel_heating")
+        assert fn(sample_coordinator_data, VIN) == "Off"
+
+    def test_none_when_no_climate(self):
+        fn = _climate_heating("steering_wheel_heating")
+        assert fn({}, VIN) is None
+
+
+class TestEstimatedRange:
+    def test_returns_km(self, sample_coordinator_data):
+        assert _estimated_range(sample_coordinator_data, VIN) == 230
+
+    def test_none_when_no_cep_battery(self):
+        data = {"cep_battery": {}}
+        assert _estimated_range(data, VIN) is None
+
+    def test_none_when_empty_data(self):
+        assert _estimated_range({}, VIN) is None
+
+    def test_none_when_range_missing(self):
+        data = {"cep_battery": {VIN: {"soc": 76.0}}}
+        assert _estimated_range(data, VIN) is None


### PR DESCRIPTION
## Summary

- Add 7 new sensors via Volvo CEP gRPC API: climate status, seat heating levels (driver, passenger, rear left, rear right), steering wheel heating, and estimated range
- Extract shared protobuf wire-format helpers to `proto.py` for reuse across gRPC clients
- New `CepClient` for the Volvo CEP gRPC API (`cepmobtoken.eu.prod.c3.volvocars.com`)
- Refactor sensor `value_fn` signature from `(vehicle, battery, odometer)` to `(data, vin)` for extensibility
- Close gRPC channels on integration unload (fixes pre-existing resource leak)
- CEP fetch failures are logged at debug level and don't block existing sensors

## Test plan

- [x] 98 unit tests passing (`pytest tests/ -v`)
- [x] Ruff lint + format clean
- [x] Verified CEP gRPC endpoints return valid data with existing `l3oopkc_10` token
- [ ] Deploy to Home Assistant and verify sensors appear under vehicle device
- [ ] Verify existing sensors (battery SOC, charging status, odometer) unaffected