### PR TITLE
Fix PCCS gRPC client and add OTP config flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ htmlcov/
 research/
 plans/
 scripts/
+pr-reviews/

--- a/custom_components/polestar_soc/config_flow.py
+++ b/custom_components/polestar_soc/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
-from .const import DOMAIN
+from .const import DOMAIN, PCCS_ACR_VALUES, PCCS_CLIENT_ID, PCCS_REDIRECT_URI, PCCS_SCOPE
 from .coordinator import PolestarAPI
 
 _LOGGER = logging.getLogger(__name__)
@@ -21,13 +21,31 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+STEP_OTP_SCHEMA = vol.Schema(
+    {
+        vol.Optional("otp", default=""): str,
+    }
+)
+
 
 class PolestarSOCConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Polestar SOC."""
 
     VERSION = 1
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._email: str = ""
+        self._password: str = ""
+        self._web_tokens: dict = {}
+        self._pccs_session_state: dict | None = None
+        self._reauth_entry: str | None = None
+
+    # -- Step: user (email + password) ---------------------------------------
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
 
@@ -57,21 +75,56 @@ class PolestarSOCConfigFlow(ConfigFlow, domain=DOMAIN):
                     if not vehicles:
                         errors["base"] = "no_vehicles"
                     else:
-                        return self.async_create_entry(
-                            title=email,
-                            data={
-                                "email": email,
-                                "password": password,
-                                "access_token": tokens["access_token"],
-                                "refresh_token": tokens.get("refresh_token"),
-                            },
-                        )
+                        # Web login succeeded — initiate PCCS 2FA
+                        self._email = email
+                        self._password = password
+                        self._web_tokens = tokens
+                        return await self._initiate_pccs_2fa(email, password)
 
         return self.async_show_form(
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
         )
+
+    # -- Step: OTP -----------------------------------------------------------
+
+    async def async_step_otp(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the OTP verification step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            otp_code = user_input.get("otp", "").strip()
+
+            pccs_tokens: dict = {}
+            if otp_code and self._pccs_session_state:
+                # User provided OTP — complete the PCCS login
+                pccs_api = PolestarAPI(
+                    client_id=PCCS_CLIENT_ID,
+                    redirect_uri=PCCS_REDIRECT_URI,
+                )
+                try:
+                    pccs_tokens = await self.hass.async_add_executor_job(
+                        pccs_api.login_complete_2fa,
+                        self._pccs_session_state,
+                        otp_code,
+                    )
+                except Exception:
+                    _LOGGER.debug("OTP verification failed", exc_info=True)
+                    errors["base"] = "invalid_otp"
+
+            if not errors:
+                return await self._finish_setup(pccs_tokens)
+
+        return self.async_show_form(
+            step_id="otp",
+            data_schema=STEP_OTP_SCHEMA,
+            errors=errors,
+        )
+
+    # -- Step: reauth --------------------------------------------------------
 
     async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
         """Handle re-authentication."""
@@ -96,22 +149,67 @@ class PolestarSOCConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected error during re-auth")
                 errors["base"] = "cannot_connect"
             else:
-                entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
-                if entry:
-                    self.hass.config_entries.async_update_entry(
-                        entry,
-                        data={
-                            "email": email,
-                            "password": password,
-                            "access_token": tokens["access_token"],
-                            "refresh_token": tokens.get("refresh_token"),
-                        },
-                    )
-                    await self.hass.config_entries.async_reload(entry.entry_id)
-                    return self.async_abort(reason="reauth_successful")
+                # Web login succeeded — initiate PCCS 2FA
+                self._email = email
+                self._password = password
+                self._web_tokens = tokens
+                self._reauth_entry = self.context["entry_id"]
+                return await self._initiate_pccs_2fa(email, password)
 
         return self.async_show_form(
             step_id="reauth_confirm",
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
         )
+
+    # -- Private helpers -----------------------------------------------------
+
+    async def _initiate_pccs_2fa(self, email: str, password: str) -> ConfigFlowResult:
+        """Trigger the PCCS 2FA email and proceed to the OTP step."""
+        pccs_api = PolestarAPI(
+            client_id=PCCS_CLIENT_ID,
+            redirect_uri=PCCS_REDIRECT_URI,
+        )
+        try:
+            result = await self.hass.async_add_executor_job(
+                pccs_api.login_start_2fa,
+                email,
+                password,
+                PCCS_SCOPE,
+                PCCS_ACR_VALUES,
+            )
+        except Exception:
+            _LOGGER.warning("Failed to initiate PCCS 2FA login", exc_info=True)
+            # PCCS setup failed — continue without it
+            self._pccs_session_state = None
+            return await self.async_step_otp()
+
+        if result.get("needs_otp"):
+            self._pccs_session_state = result["_session_state"]
+        else:
+            # No 2FA required — tokens returned directly, skip OTP step
+            return await self._finish_setup(result)
+
+        return await self.async_step_otp()
+
+    async def _finish_setup(self, pccs_tokens: dict) -> ConfigFlowResult:
+        """Create or update the config entry with web + PCCS tokens."""
+        entry_data = {
+            "email": self._email,
+            "password": self._password,
+            "access_token": self._web_tokens["access_token"],
+            "refresh_token": self._web_tokens.get("refresh_token"),
+            "pccs_access_token": pccs_tokens.get("access_token"),
+            "pccs_refresh_token": pccs_tokens.get("refresh_token"),
+        }
+
+        if self._reauth_entry:
+            # Reauth — update existing entry
+            entry = self.hass.config_entries.async_get_entry(self._reauth_entry)
+            if not entry:
+                return self.async_abort(reason="reauth_successful")
+            self.hass.config_entries.async_update_entry(entry, data=entry_data)
+            await self.hass.config_entries.async_reload(entry.entry_id)
+            return self.async_abort(reason="reauth_successful")
+
+        return self.async_create_entry(title=self._email, data=entry_data)

--- a/custom_components/polestar_soc/config_flow.py
+++ b/custom_components/polestar_soc/config_flow.py
@@ -43,9 +43,7 @@ class PolestarSOCConfigFlow(ConfigFlow, domain=DOMAIN):
 
     # -- Step: user (email + password) ---------------------------------------
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
 
@@ -89,9 +87,7 @@ class PolestarSOCConfigFlow(ConfigFlow, domain=DOMAIN):
 
     # -- Step: OTP -----------------------------------------------------------
 
-    async def async_step_otp(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
+    async def async_step_otp(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle the OTP verification step."""
         errors: dict[str, str] = {}
 

--- a/custom_components/polestar_soc/const.py
+++ b/custom_components/polestar_soc/const.py
@@ -9,9 +9,17 @@ SCAN_INTERVAL = timedelta(minutes=5)
 OIDC_BASE_URL = "https://polestarid.eu.polestar.com"
 OIDC_AUTH_URL = f"{OIDC_BASE_URL}/as/authorization.oauth2"
 OIDC_TOKEN_URL = f"{OIDC_BASE_URL}/as/token.oauth2"
+
+# Web client — used for GraphQL (mystar-v2)
 CLIENT_ID = "l3oopkc_10"
 REDIRECT_URI = "https://www.polestar.com/sign-in-callback"
 SCOPE = "openid profile email customer:attributes"
+
+# Mobile app client — used for PCCS gRPC (requires broader scope + 2SV)
+PCCS_CLIENT_ID = "lp8dyrd_10"
+PCCS_REDIRECT_URI = "polestar-explore://explore.polestar.com"
+PCCS_SCOPE = "openid profile email customer:attributes customer:attributes:write"
+PCCS_ACR_VALUES = "urn:volvoid:aal:bronze:2sv"
 
 # GraphQL API
 API_URL = "https://pc-api.polestar.com/eu-north-1/mystar-v2/"

--- a/custom_components/polestar_soc/const.py
+++ b/custom_components/polestar_soc/const.py
@@ -15,7 +15,7 @@ CLIENT_ID = "l3oopkc_10"
 REDIRECT_URI = "https://www.polestar.com/sign-in-callback"
 SCOPE = "openid profile email customer:attributes"
 
-# Mobile app client — used for PCCS gRPC (requires broader scope + 2SV)
+# PCCS client — used for PCCS gRPC (requires broader scope + 2SV)
 PCCS_CLIENT_ID = "lp8dyrd_10"
 PCCS_REDIRECT_URI = "polestar-explore://explore.polestar.com"
 PCCS_SCOPE = "openid profile email customer:attributes customer:attributes:write"

--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -24,6 +24,10 @@ from .const import (
     OIDC_AUTH_URL,
     OIDC_BASE_URL,
     OIDC_TOKEN_URL,
+    PCCS_ACR_VALUES,
+    PCCS_CLIENT_ID,
+    PCCS_REDIRECT_URI,
+    PCCS_SCOPE,
     QUERY_GET_CARS,
     QUERY_TELEMATICS,
     REDIRECT_URI,
@@ -44,12 +48,30 @@ def _b64urlencode(data: bytes) -> str:
 class PolestarAPI:
     """Handle Polestar OAuth2 PKCE authentication and GraphQL queries."""
 
-    def __init__(self) -> None:
+    def __init__(self, otp_callback: callable | None = None) -> None:
         self.access_token: str | None = None
         self.refresh_token: str | None = None
+        self._otp_callback = otp_callback
 
-    def login(self, email: str, password: str) -> dict:
+    def _get_otp_code(self) -> str | None:
+        """Get OTP code for 2FA via callback."""
+        if self._otp_callback:
+            return self._otp_callback()
+        return None
+
+    def login(
+        self,
+        email: str,
+        password: str,
+        client_id: str = CLIENT_ID,
+        redirect_uri: str = REDIRECT_URI,
+        scope: str = SCOPE,
+        acr_values: str | None = None,
+    ) -> dict:
         """Perform full OAuth2 Authorization Code + PKCE login."""
+        self._client_id = client_id
+        self._redirect_uri = redirect_uri
+
         code_verifier = _b64urlencode(os.urandom(32))
         code_challenge = _b64urlencode(hashlib.sha256(code_verifier.encode()).digest())
         state = _b64urlencode(os.urandom(12))
@@ -57,17 +79,20 @@ class PolestarAPI:
         session = requests.Session()
 
         # Step 1: Authorization request
+        auth_params = {
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "state": state,
+            "scope": scope,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+        if acr_values:
+            auth_params["acr_values"] = acr_values
         resp = session.get(
             OIDC_AUTH_URL,
-            params={
-                "client_id": CLIENT_ID,
-                "redirect_uri": REDIRECT_URI,
-                "response_type": "code",
-                "state": state,
-                "scope": SCOPE,
-                "code_challenge": code_challenge,
-                "code_challenge_method": "S256",
-            },
+            params=auth_params,
             allow_redirects=True,
             timeout=HTTP_TIMEOUT,
         )
@@ -86,7 +111,7 @@ class PolestarAPI:
             data={
                 "pf.username": email,
                 "pf.pass": password,
-                "client_id": CLIENT_ID,
+                "client_id": client_id,
             },
             allow_redirects=False,
             timeout=HTTP_TIMEOUT,
@@ -95,7 +120,55 @@ class PolestarAPI:
         if resp.status_code not in (302, 303):
             if "ERR001" in resp.text or "authMessage" in resp.text:
                 raise ConfigEntryAuthFailed("Invalid email or password")
-            raise UpdateFailed(f"Unexpected login response ({resp.status_code})")
+
+            # 2SV: server returned OTP challenge page (200 with form)
+            if resp.status_code == 200:
+                # Extract action URL from JS globalContext
+                action_match = re.search(
+                    r'action:\s*"(/as/[^"]+/resume/as/authorization\.ping)"',
+                    resp.text,
+                )
+                otp_resume = (
+                    OIDC_BASE_URL + action_match.group(1)
+                    if action_match
+                    else resume_url
+                )
+
+                otp_code = self._get_otp_code()
+                if not otp_code:
+                    raise UpdateFailed("2FA code required but not provided")
+
+                _LOGGER.debug("Submitting OTP to %s", otp_resume)
+                resp = session.post(
+                    otp_resume,
+                    data={"otp": otp_code},
+                    allow_redirects=False,
+                    timeout=HTTP_TIMEOUT,
+                )
+                # OTP success returns a page with auto-submit form
+                if "otp-success-form" in resp.text:
+                    action_match2 = re.search(
+                        r'action="(/as/[^"]+/resume/as/authorization\.ping)"',
+                        resp.text,
+                    )
+                    continue_url = (
+                        OIDC_BASE_URL + action_match2.group(1)
+                        if action_match2
+                        else otp_resume
+                    )
+                    resp = session.post(
+                        continue_url,
+                        data={"continue.authentication": "true"},
+                        allow_redirects=False,
+                        timeout=HTTP_TIMEOUT,
+                    )
+
+                if resp.status_code not in (302, 303):
+                    raise UpdateFailed(
+                        f"2FA verification failed ({resp.status_code})"
+                    )
+            else:
+                raise UpdateFailed(f"Unexpected login response ({resp.status_code})")
 
         redirect_url = resp.headers.get("Location", "")
         parsed = urlparse(redirect_url)
@@ -136,8 +209,8 @@ class PolestarAPI:
                 "grant_type": "authorization_code",
                 "code": auth_code,
                 "code_verifier": code_verifier,
-                "client_id": CLIENT_ID,
-                "redirect_uri": REDIRECT_URI,
+                "client_id": client_id,
+                "redirect_uri": redirect_uri,
             },
             headers={"Accept": "application/json"},
             timeout=HTTP_TIMEOUT,
@@ -154,12 +227,13 @@ class PolestarAPI:
 
     def refresh_tokens(self, refresh_token: str) -> dict:
         """Refresh the access token using a refresh token."""
+        client_id = getattr(self, "_client_id", CLIENT_ID)
         resp = requests.post(
             OIDC_TOKEN_URL,
             data={
                 "grant_type": "refresh_token",
                 "refresh_token": refresh_token,
-                "client_id": CLIENT_ID,
+                "client_id": client_id,
             },
             headers={"Accept": "application/json"},
             timeout=HTTP_TIMEOUT,
@@ -221,7 +295,13 @@ class PolestarCoordinator(DataUpdateCoordinator):
         self.api = PolestarAPI()
         self.api.access_token = entry.data.get("access_token")
         self.api.refresh_token = entry.data.get("refresh_token")
-        self.pccs = PccsClient(self.api.access_token or "")
+
+        # Separate API instance for PCCS (needs iOS client_id)
+        self._pccs_api = PolestarAPI()
+        self._pccs_api.access_token = entry.data.get("pccs_access_token")
+        self._pccs_api.refresh_token = entry.data.get("pccs_refresh_token")
+
+        self.pccs = PccsClient(self._pccs_api.access_token or "")
         self.cep = CepClient(self.api.access_token or "")
         self._email: str = entry.data["email"]
         self._password: str = entry.data["password"]
@@ -246,21 +326,40 @@ class PolestarCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"API error after re-auth: {err}") from err
 
     async def _refresh_or_relogin(self) -> None:
-        """Try token refresh, fall back to full re-login."""
-        if self.api.refresh_token:
+        """Try token refresh, fall back to full re-login for both API clients."""
+        # Refresh/relogin the main (web) API
+        await self._refresh_or_relogin_api(self.api, CLIENT_ID, REDIRECT_URI, SCOPE)
+        # Refresh/relogin the PCCS (mobile) API
+        await self._refresh_or_relogin_api(
+            self._pccs_api, PCCS_CLIENT_ID, PCCS_REDIRECT_URI, PCCS_SCOPE,
+            acr_values=PCCS_ACR_VALUES,
+        )
+        self._update_stored_tokens()
+
+    async def _refresh_or_relogin_api(
+        self,
+        api: PolestarAPI,
+        client_id: str,
+        redirect_uri: str,
+        scope: str,
+        acr_values: str | None = None,
+    ) -> None:
+        """Try token refresh, fall back to full re-login for a single API client."""
+        if api.refresh_token:
             try:
                 await self.hass.async_add_executor_job(
-                    self.api.refresh_tokens, self.api.refresh_token
+                    api.refresh_tokens, api.refresh_token
                 )
-                self._update_stored_tokens()
                 return
             except Exception:
-                _LOGGER.debug("Refresh token failed, doing full re-login")
+                _LOGGER.debug("Refresh token failed for %s, doing full re-login", client_id)
 
         # Full re-login
         try:
-            await self.hass.async_add_executor_job(self.api.login, self._email, self._password)
-            self._update_stored_tokens()
+            await self.hass.async_add_executor_job(
+                api.login, self._email, self._password,
+                client_id, redirect_uri, scope, acr_values,
+            )
         except ConfigEntryAuthFailed:
             raise
         except Exception as err:
@@ -343,10 +442,12 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 **self.config_entry.data,
                 "access_token": self.api.access_token,
                 "refresh_token": self.api.refresh_token,
+                "pccs_access_token": self._pccs_api.access_token,
+                "pccs_refresh_token": self._pccs_api.refresh_token,
             },
         )
         # Keep gRPC client tokens in sync
-        self.pccs.access_token = self.api.access_token or ""
+        self.pccs.access_token = self._pccs_api.access_token or ""
         self.cep.access_token = self.api.access_token or ""
 
     def close(self) -> None:

--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -135,11 +135,7 @@ class PolestarAPI:
                     r'action:\s*"(/as/[^"]+/resume/as/authorization\.ping)"',
                     resp.text,
                 )
-                otp_resume = (
-                    OIDC_BASE_URL + action_match.group(1)
-                    if action_match
-                    else resume_url
-                )
+                otp_resume = OIDC_BASE_URL + action_match.group(1) if action_match else resume_url
 
                 otp_code = self._get_otp_code()
                 if not otp_code:
@@ -159,9 +155,7 @@ class PolestarAPI:
                         resp.text,
                     )
                     continue_url = (
-                        OIDC_BASE_URL + action_match2.group(1)
-                        if action_match2
-                        else otp_resume
+                        OIDC_BASE_URL + action_match2.group(1) if action_match2 else otp_resume
                     )
                     resp = session.post(
                         continue_url,
@@ -171,9 +165,7 @@ class PolestarAPI:
                     )
 
                 if resp.status_code not in (302, 303):
-                    raise UpdateFailed(
-                        f"2FA verification failed ({resp.status_code})"
-                    )
+                    raise UpdateFailed(f"2FA verification failed ({resp.status_code})")
             else:
                 raise UpdateFailed(f"Unexpected login response ({resp.status_code})")
 
@@ -305,7 +297,8 @@ class PolestarCoordinator(DataUpdateCoordinator):
 
         # Separate API instance for PCCS (needs mobile client_id)
         self._pccs_api = PolestarAPI(
-            client_id=PCCS_CLIENT_ID, redirect_uri=PCCS_REDIRECT_URI,
+            client_id=PCCS_CLIENT_ID,
+            redirect_uri=PCCS_REDIRECT_URI,
         )
         self._pccs_api.access_token = entry.data.get("pccs_access_token")
         self._pccs_api.refresh_token = entry.data.get("pccs_refresh_token")
@@ -343,7 +336,10 @@ class PolestarCoordinator(DataUpdateCoordinator):
         # (re-login requires 2FA which can't be done in background)
         try:
             await self._refresh_or_relogin_api(
-                self._pccs_api, PCCS_CLIENT_ID, PCCS_REDIRECT_URI, PCCS_SCOPE,
+                self._pccs_api,
+                PCCS_CLIENT_ID,
+                PCCS_REDIRECT_URI,
+                PCCS_SCOPE,
                 acr_values=PCCS_ACR_VALUES,
             )
         except Exception:
@@ -364,9 +360,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
         """Try token refresh, fall back to full re-login for a single API client."""
         if api.refresh_token:
             try:
-                await self.hass.async_add_executor_job(
-                    api.refresh_tokens, api.refresh_token
-                )
+                await self.hass.async_add_executor_job(api.refresh_tokens, api.refresh_token)
                 return
             except Exception:
                 _LOGGER.debug("Refresh token failed for %s, doing full re-login", client_id)
@@ -374,8 +368,13 @@ class PolestarCoordinator(DataUpdateCoordinator):
         # Full re-login
         try:
             await self.hass.async_add_executor_job(
-                api.login, self._email, self._password,
-                client_id, redirect_uri, scope, acr_values,
+                api.login,
+                self._email,
+                self._password,
+                client_id,
+                redirect_uri,
+                scope,
+                acr_values,
             )
         except ConfigEntryAuthFailed:
             raise

--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -153,9 +153,7 @@ class PolestarAPI:
                 r'action="(/as/[^"]+/resume/as/authorization\.ping)"',
                 resp.text,
             )
-            continue_url = (
-                OIDC_BASE_URL + action_match.group(1) if action_match else otp_resume
-            )
+            continue_url = OIDC_BASE_URL + action_match.group(1) if action_match else otp_resume
             resp = session.post(
                 continue_url,
                 data={"continue.authentication": "true"},

--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -7,6 +7,7 @@ import hashlib
 import logging
 import os
 import re
+from collections.abc import Callable
 from urllib.parse import parse_qs, urlparse
 
 import requests
@@ -48,9 +49,16 @@ def _b64urlencode(data: bytes) -> str:
 class PolestarAPI:
     """Handle Polestar OAuth2 PKCE authentication and GraphQL queries."""
 
-    def __init__(self, otp_callback: callable | None = None) -> None:
+    def __init__(
+        self,
+        client_id: str = CLIENT_ID,
+        redirect_uri: str = REDIRECT_URI,
+        otp_callback: Callable[[], str | None] | None = None,
+    ) -> None:
         self.access_token: str | None = None
         self.refresh_token: str | None = None
+        self._client_id = client_id
+        self._redirect_uri = redirect_uri
         self._otp_callback = otp_callback
 
     def _get_otp_code(self) -> str | None:
@@ -71,7 +79,6 @@ class PolestarAPI:
         """Perform full OAuth2 Authorization Code + PKCE login."""
         self._client_id = client_id
         self._redirect_uri = redirect_uri
-
         code_verifier = _b64urlencode(os.urandom(32))
         code_challenge = _b64urlencode(hashlib.sha256(code_verifier.encode()).digest())
         state = _b64urlencode(os.urandom(12))
@@ -227,7 +234,7 @@ class PolestarAPI:
 
     def refresh_tokens(self, refresh_token: str) -> dict:
         """Refresh the access token using a refresh token."""
-        client_id = getattr(self, "_client_id", CLIENT_ID)
+        client_id = self._client_id
         resp = requests.post(
             OIDC_TOKEN_URL,
             data={
@@ -296,8 +303,10 @@ class PolestarCoordinator(DataUpdateCoordinator):
         self.api.access_token = entry.data.get("access_token")
         self.api.refresh_token = entry.data.get("refresh_token")
 
-        # Separate API instance for PCCS (needs iOS client_id)
-        self._pccs_api = PolestarAPI()
+        # Separate API instance for PCCS (needs mobile client_id)
+        self._pccs_api = PolestarAPI(
+            client_id=PCCS_CLIENT_ID, redirect_uri=PCCS_REDIRECT_URI,
+        )
         self._pccs_api.access_token = entry.data.get("pccs_access_token")
         self._pccs_api.refresh_token = entry.data.get("pccs_refresh_token")
 
@@ -327,13 +336,21 @@ class PolestarCoordinator(DataUpdateCoordinator):
 
     async def _refresh_or_relogin(self) -> None:
         """Try token refresh, fall back to full re-login for both API clients."""
-        # Refresh/relogin the main (web) API
+        # Refresh/relogin the main (web) API — failure is fatal
         await self._refresh_or_relogin_api(self.api, CLIENT_ID, REDIRECT_URI, SCOPE)
-        # Refresh/relogin the PCCS (mobile) API
-        await self._refresh_or_relogin_api(
-            self._pccs_api, PCCS_CLIENT_ID, PCCS_REDIRECT_URI, PCCS_SCOPE,
-            acr_values=PCCS_ACR_VALUES,
-        )
+        self._update_stored_tokens()
+        # Refresh/relogin the PCCS (mobile) API — failure is non-fatal
+        # (re-login requires 2FA which can't be done in background)
+        try:
+            await self._refresh_or_relogin_api(
+                self._pccs_api, PCCS_CLIENT_ID, PCCS_REDIRECT_URI, PCCS_SCOPE,
+                acr_values=PCCS_ACR_VALUES,
+            )
+        except Exception:
+            _LOGGER.warning(
+                "PCCS token refresh failed; PCCS sensors will be unavailable "
+                "until the integration is reconfigured"
+            )
         self._update_stored_tokens()
 
     async def _refresh_or_relogin_api(

--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -25,10 +25,8 @@ from .const import (
     OIDC_AUTH_URL,
     OIDC_BASE_URL,
     OIDC_TOKEN_URL,
-    PCCS_ACR_VALUES,
     PCCS_CLIENT_ID,
     PCCS_REDIRECT_URI,
-    PCCS_SCOPE,
     QUERY_GET_CARS,
     QUERY_TELEMATICS,
     REDIRECT_URI,
@@ -61,31 +59,36 @@ class PolestarAPI:
         self._redirect_uri = redirect_uri
         self._otp_callback = otp_callback
 
+    @property
+    def client_id(self) -> str:
+        """Return the OAuth2 client_id for this API instance."""
+        return self._client_id
+
     def _get_otp_code(self) -> str | None:
         """Get OTP code for 2FA via callback."""
         if self._otp_callback:
             return self._otp_callback()
         return None
 
-    def login(
+    # -- Private auth helpers ------------------------------------------------
+
+    def _start_auth_session(
         self,
-        email: str,
-        password: str,
-        client_id: str = CLIENT_ID,
-        redirect_uri: str = REDIRECT_URI,
-        scope: str = SCOPE,
+        scope: str,
         acr_values: str | None = None,
-    ) -> dict:
-        """Perform full OAuth2 Authorization Code + PKCE login."""
-        self._client_id = client_id
-        self._redirect_uri = redirect_uri
+    ) -> tuple[requests.Session, str, str]:
+        """Start OAuth2 PKCE session: auth request + extract resume URL.
+
+        Returns (session, resume_url, code_verifier).
+        """
+        client_id = self._client_id
+        redirect_uri = self._redirect_uri
         code_verifier = _b64urlencode(os.urandom(32))
         code_challenge = _b64urlencode(hashlib.sha256(code_verifier.encode()).digest())
         state = _b64urlencode(os.urandom(12))
 
         session = requests.Session()
 
-        # Step 1: Authorization request
         auth_params = {
             "client_id": client_id,
             "redirect_uri": redirect_uri,
@@ -105,75 +108,74 @@ class PolestarAPI:
         )
         resp.raise_for_status()
 
-        # Step 2: Extract resume path
         match = re.search(r"(/as/[^/]+/resume/as/authorization\.ping)", resp.text)
         if not match:
             raise UpdateFailed("Could not find login form endpoint")
 
         resume_url = OIDC_BASE_URL + match.group(1)
+        return session, resume_url, code_verifier
 
-        # Step 3: Submit credentials
-        resp = session.post(
+    def _submit_credentials(
+        self,
+        session: requests.Session,
+        resume_url: str,
+        email: str,
+        password: str,
+    ) -> requests.Response:
+        """POST credentials to the login form. Returns the response."""
+        return session.post(
             resume_url,
             data={
                 "pf.username": email,
                 "pf.pass": password,
-                "client_id": client_id,
+                "client_id": self._client_id,
             },
             allow_redirects=False,
             timeout=HTTP_TIMEOUT,
         )
 
-        if resp.status_code not in (302, 303):
-            if "ERR001" in resp.text or "authMessage" in resp.text:
-                raise ConfigEntryAuthFailed("Invalid email or password")
+    @staticmethod
+    def _submit_otp(
+        session: requests.Session,
+        otp_resume: str,
+        otp_code: str,
+    ) -> requests.Response:
+        """Submit OTP code and handle the success-form continuation."""
+        resp = session.post(
+            otp_resume,
+            data={"otp": otp_code},
+            allow_redirects=False,
+            timeout=HTTP_TIMEOUT,
+        )
+        # OTP success returns a page with auto-submit form
+        if "otp-success-form" in resp.text:
+            action_match = re.search(
+                r'action="(/as/[^"]+/resume/as/authorization\.ping)"',
+                resp.text,
+            )
+            continue_url = (
+                OIDC_BASE_URL + action_match.group(1) if action_match else otp_resume
+            )
+            resp = session.post(
+                continue_url,
+                data={"continue.authentication": "true"},
+                allow_redirects=False,
+                timeout=HTTP_TIMEOUT,
+            )
+        return resp
 
-            # 2SV: server returned OTP challenge page (200 with form)
-            if resp.status_code == 200:
-                # Extract action URL from JS globalContext
-                action_match = re.search(
-                    r'action:\s*"(/as/[^"]+/resume/as/authorization\.ping)"',
-                    resp.text,
-                )
-                otp_resume = OIDC_BASE_URL + action_match.group(1) if action_match else resume_url
-
-                otp_code = self._get_otp_code()
-                if not otp_code:
-                    raise UpdateFailed("2FA code required but not provided")
-
-                _LOGGER.debug("Submitting OTP to %s", otp_resume)
-                resp = session.post(
-                    otp_resume,
-                    data={"otp": otp_code},
-                    allow_redirects=False,
-                    timeout=HTTP_TIMEOUT,
-                )
-                # OTP success returns a page with auto-submit form
-                if "otp-success-form" in resp.text:
-                    action_match2 = re.search(
-                        r'action="(/as/[^"]+/resume/as/authorization\.ping)"',
-                        resp.text,
-                    )
-                    continue_url = (
-                        OIDC_BASE_URL + action_match2.group(1) if action_match2 else otp_resume
-                    )
-                    resp = session.post(
-                        continue_url,
-                        data={"continue.authentication": "true"},
-                        allow_redirects=False,
-                        timeout=HTTP_TIMEOUT,
-                    )
-
-                if resp.status_code not in (302, 303):
-                    raise UpdateFailed(f"2FA verification failed ({resp.status_code})")
-            else:
-                raise UpdateFailed(f"Unexpected login response ({resp.status_code})")
-
+    @staticmethod
+    def _extract_auth_code(
+        session: requests.Session,
+        resp: requests.Response,
+        resume_url: str,
+    ) -> str:
+        """Extract auth code from redirect, handling consent if needed."""
         redirect_url = resp.headers.get("Location", "")
         parsed = urlparse(redirect_url)
         params = parse_qs(parsed.query)
 
-        # Step 3a: Handle consent/confirmation
+        # Handle consent/confirmation
         if "code" not in params and "uid" in params:
             uid = params["uid"][0]
             resp = session.post(
@@ -199,17 +201,23 @@ class PolestarAPI:
         if "code" not in params:
             raise UpdateFailed("No authorization code received")
 
-        auth_code = params["code"][0]
+        return params["code"][0]
 
-        # Step 4: Exchange code for tokens
+    def _exchange_code_for_tokens(
+        self,
+        session: requests.Session,
+        auth_code: str,
+        code_verifier: str,
+    ) -> dict:
+        """Exchange authorization code for tokens and store them."""
         resp = session.post(
             OIDC_TOKEN_URL,
             data={
                 "grant_type": "authorization_code",
                 "code": auth_code,
                 "code_verifier": code_verifier,
-                "client_id": client_id,
-                "redirect_uri": redirect_uri,
+                "client_id": self._client_id,
+                "redirect_uri": self._redirect_uri,
             },
             headers={"Accept": "application/json"},
             timeout=HTTP_TIMEOUT,
@@ -223,6 +231,122 @@ class PolestarAPI:
         self.access_token = tokens["access_token"]
         self.refresh_token = tokens.get("refresh_token")
         return tokens
+
+    @staticmethod
+    def _detect_otp_challenge(resp: requests.Response, resume_url: str) -> str | None:
+        """Check if a credential-POST response is a 2FA challenge.
+
+        Returns the OTP resume URL if 2FA is required, or None.
+        """
+        if resp.status_code in (302, 303):
+            return None  # No 2FA — redirect means success
+        if resp.status_code != 200:
+            return None  # Not an OTP page
+        if "ERR001" in resp.text or "authMessage" in resp.text:
+            return None  # Auth error, not OTP
+        action_match = re.search(
+            r'action:\s*"(/as/[^"]+/resume/as/authorization\.ping)"',
+            resp.text,
+        )
+        if not action_match:
+            return None
+        return OIDC_BASE_URL + action_match.group(1)
+
+    # -- Public login methods ------------------------------------------------
+
+    def login(
+        self,
+        email: str,
+        password: str,
+        scope: str = SCOPE,
+        acr_values: str | None = None,
+    ) -> dict:
+        """Perform full OAuth2 Authorization Code + PKCE login."""
+        session, resume_url, code_verifier = self._start_auth_session(scope, acr_values)
+        resp = self._submit_credentials(session, resume_url, email, password)
+
+        if resp.status_code not in (302, 303):
+            if "ERR001" in resp.text or "authMessage" in resp.text:
+                raise ConfigEntryAuthFailed("Invalid email or password")
+
+            # 2SV: server returned OTP challenge page (200 with form)
+            otp_resume = self._detect_otp_challenge(resp, resume_url)
+            if otp_resume:
+                otp_code = self._get_otp_code()
+                if not otp_code:
+                    raise UpdateFailed("2FA code required but not provided")
+
+                _LOGGER.debug("Submitting OTP to %s", otp_resume)
+                resp = self._submit_otp(session, otp_resume, otp_code)
+
+                if resp.status_code not in (302, 303):
+                    raise UpdateFailed(f"2FA verification failed ({resp.status_code})")
+            else:
+                raise UpdateFailed(f"Unexpected login response ({resp.status_code})")
+
+        auth_code = self._extract_auth_code(session, resp, resume_url)
+        return self._exchange_code_for_tokens(session, auth_code, code_verifier)
+
+    def login_start_2fa(
+        self,
+        email: str,
+        password: str,
+        scope: str = SCOPE,
+        acr_values: str | None = None,
+    ) -> dict:
+        """Start login with 2FA. Triggers OTP email.
+
+        Returns a dict with ``"needs_otp": True`` and an opaque
+        ``"_session_state"`` if the server challenges for OTP.
+        If no 2FA is required, completes the flow and returns tokens
+        (with ``"access_token"`` present).
+        """
+        session, resume_url, code_verifier = self._start_auth_session(scope, acr_values)
+        resp = self._submit_credentials(session, resume_url, email, password)
+
+        if resp.status_code not in (302, 303):
+            if "ERR001" in resp.text or "authMessage" in resp.text:
+                raise ConfigEntryAuthFailed("Invalid email or password")
+
+            otp_resume = self._detect_otp_challenge(resp, resume_url)
+            if otp_resume:
+                # 2FA triggered — return session state for the caller to
+                # collect the OTP code and call login_complete_2fa().
+                return {
+                    "needs_otp": True,
+                    "_session_state": {
+                        "session": session,
+                        "otp_resume": otp_resume,
+                        "resume_url": resume_url,
+                        "code_verifier": code_verifier,
+                    },
+                }
+
+            raise UpdateFailed(f"Unexpected login response ({resp.status_code})")
+
+        # No 2FA — complete the flow directly
+        auth_code = self._extract_auth_code(session, resp, resume_url)
+        return self._exchange_code_for_tokens(session, auth_code, code_verifier)
+
+    def login_complete_2fa(self, session_state: dict, otp_code: str) -> dict:
+        """Complete 2FA login by submitting the OTP code.
+
+        ``session_state`` is the ``"_session_state"`` dict returned by
+        ``login_start_2fa``.
+        """
+        session: requests.Session = session_state["session"]
+        otp_resume: str = session_state["otp_resume"]
+        resume_url: str = session_state["resume_url"]
+        code_verifier: str = session_state["code_verifier"]
+
+        _LOGGER.debug("Submitting OTP to %s", otp_resume)
+        resp = self._submit_otp(session, otp_resume, otp_code)
+
+        if resp.status_code not in (302, 303):
+            raise UpdateFailed(f"2FA verification failed ({resp.status_code})")
+
+        auth_code = self._extract_auth_code(session, resp, resume_url)
+        return self._exchange_code_for_tokens(session, auth_code, code_verifier)
 
     def refresh_tokens(self, refresh_token: str) -> dict:
         """Refresh the access token using a refresh token."""
@@ -295,7 +419,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
         self.api.access_token = entry.data.get("access_token")
         self.api.refresh_token = entry.data.get("refresh_token")
 
-        # Separate API instance for PCCS (needs mobile client_id)
+        # Separate API instance for PCCS (needs PCCS client_id)
         self._pccs_api = PolestarAPI(
             client_id=PCCS_CLIENT_ID,
             redirect_uri=PCCS_REDIRECT_URI,
@@ -330,31 +454,27 @@ class PolestarCoordinator(DataUpdateCoordinator):
     async def _refresh_or_relogin(self) -> None:
         """Try token refresh, fall back to full re-login for both API clients."""
         # Refresh/relogin the main (web) API — failure is fatal
-        await self._refresh_or_relogin_api(self.api, CLIENT_ID, REDIRECT_URI, SCOPE)
+        await self._refresh_or_relogin_api(self.api)
         self._update_stored_tokens()
-        # Refresh/relogin the PCCS (mobile) API — failure is non-fatal
-        # (re-login requires 2FA which can't be done in background)
-        try:
-            await self._refresh_or_relogin_api(
-                self._pccs_api,
-                PCCS_CLIENT_ID,
-                PCCS_REDIRECT_URI,
-                PCCS_SCOPE,
-                acr_values=PCCS_ACR_VALUES,
-            )
-        except Exception:
-            _LOGGER.warning(
-                "PCCS token refresh failed; PCCS sensors will be unavailable "
-                "until the integration is reconfigured"
-            )
+        # Refresh the PCCS API — only try token refresh, not
+        # full re-login (which requires 2FA and can't be done in background).
+        if self._pccs_api.refresh_token:
+            try:
+                await self.hass.async_add_executor_job(
+                    self._pccs_api.refresh_tokens, self._pccs_api.refresh_token
+                )
+            except Exception:
+                _LOGGER.warning(
+                    "PCCS token refresh failed; PCCS sensors will be unavailable "
+                    "until the integration is reconfigured",
+                    exc_info=True,
+                )
         self._update_stored_tokens()
 
     async def _refresh_or_relogin_api(
         self,
         api: PolestarAPI,
-        client_id: str,
-        redirect_uri: str,
-        scope: str,
+        scope: str = SCOPE,
         acr_values: str | None = None,
     ) -> None:
         """Try token refresh, fall back to full re-login for a single API client."""
@@ -363,7 +483,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 await self.hass.async_add_executor_job(api.refresh_tokens, api.refresh_token)
                 return
             except Exception:
-                _LOGGER.debug("Refresh token failed for %s, doing full re-login", client_id)
+                _LOGGER.debug("Refresh token failed for %s, doing full re-login", api.client_id)
 
         # Full re-login
         try:
@@ -371,8 +491,6 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 api.login,
                 self._email,
                 self._password,
-                client_id,
-                redirect_uri,
                 scope,
                 acr_values,
             )

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -9,7 +9,9 @@ with manual protobuf wire-format encoding/decoding.
 
 from __future__ import annotations
 
+import datetime
 import logging
+import uuid
 
 import grpc
 
@@ -29,8 +31,8 @@ from .proto import (
 _LOGGER = logging.getLogger(__name__)
 
 # gRPC service method paths
-_SVC_TARGET_SOC = "/chronos.services.v1.TargetSocService"
-_SVC_CHARGE_TIMER = "/chronos.services.v2.GlobalChargeTimerService"
+_SVC_TARGET_SOC = "/pccs.chronos.services.v1.TargetSocService"
+_SVC_CHARGE_TIMER = "/pccs.chronos.services.v2.GlobalChargeTimerService"
 
 _METHOD_GET_TARGET_SOC = f"{_SVC_TARGET_SOC}/GetTargetSoc"
 _METHOD_SET_TARGET_SOC = f"{_SVC_TARGET_SOC}/SetTargetSoc"
@@ -64,9 +66,39 @@ _METHOD_SET_CHARGE_TIMER = f"{_SVC_CHARGE_TIMER}/SetGlobalChargeTimer"
 #   2: minutes (int32)
 
 
-def _build_set_target_soc_request(target_soc: int) -> bytes:
+def _build_chronos_request(vin: str) -> bytes:
+    """Build a ChronosRequest sub-message.
+
+    ChronosRequest (pccs.chronos.messages.common.v1):
+        field 1: id (string)       — random UUID
+        field 2: vin (string)      — vehicle VIN
+        field 3: source (string)   — "RCS" (Remote Car Service)
+        field 4: timeZone (message) — offset in minutes
+    """
+    msg = b""
+    msg += _encode_field_bytes(1, str(uuid.uuid4()).encode("utf-8"))
+    msg += _encode_field_bytes(2, vin.encode("utf-8"))
+    msg += _encode_field_bytes(3, b"RCS")
+    # TimeZone message: field 1 = offsetMinutes (signed varint)
+    utc_offset = datetime.datetime.now(datetime.timezone.utc).astimezone().utcoffset()
+    offset_minutes = int(utc_offset.total_seconds()) // 60
+    # Proto3 int32: negative values need two's-complement encoding as uint64
+    encoded_offset = offset_minutes if offset_minutes >= 0 else offset_minutes + (1 << 64)
+    tz_msg = _encode_field_varint(1, encoded_offset)
+    msg += _encode_field_bytes(4, tz_msg)
+    return msg
+
+
+def _build_get_request(vin: str) -> bytes:
+    """Build a Get*Request wrapping a ChronosRequest in field 1."""
+    return _encode_field_bytes(1, _build_chronos_request(vin))
+
+
+def _build_set_target_soc_request(vin: str, target_soc: int) -> bytes:
     """Build SetTargetSoc request bytes."""
-    return _encode_field_varint(1, target_soc)
+    msg = _encode_field_bytes(1, _build_chronos_request(vin))
+    msg += _encode_field_varint(2, target_soc)
+    return msg
 
 
 def _build_time_of_day(hours: int, minutes: int) -> bytes:
@@ -80,44 +112,53 @@ def _build_time_of_day(hours: int, minutes: int) -> bytes:
 
 
 def _build_set_charge_timer_request(
+    vin: str,
     start_hour: int,
     start_min: int,
     end_hour: int,
     end_min: int,
 ) -> bytes:
     """Build SetGlobalChargeTimer request bytes."""
-    msg = b""
-    msg += _encode_field_bytes(1, _build_time_of_day(start_hour, start_min))
-    msg += _encode_field_bytes(2, _build_time_of_day(end_hour, end_min))
+    msg = _encode_field_bytes(1, _build_chronos_request(vin))
+    msg += _encode_field_bytes(2, _build_time_of_day(start_hour, start_min))
+    msg += _encode_field_bytes(3, _build_time_of_day(end_hour, end_min))
     return msg
 
 
 def _parse_target_soc_response(data: bytes) -> dict:
-    """Parse GetTargetSoc / SetTargetSoc response."""
+    """Parse GetTargetSocResponse / SetTargetSocResponse.
+
+    Response structure (GetTargetSocResponse):
+        field 1: id (string)           — echoed request ID
+        field 2: vin (string)          — echoed VIN
+        field 3: targetSoc (TargetSoc) — current target SOC data
+        field 4: pendingTargetSoc (TargetSoc) — pending change
+        field 5: updatedAt (varint)    — server timestamp
+
+    TargetSoc sub-message:
+        field 1: batteryChargeTargetLevel (int32)
+        field 2: chargeTargetLevelSettingType (enum: 1=DAILY, 2=LONG_TRIP, 3=CUSTOM)
+        field 3: updatedAt (varint)
+        field 4: source (string)
+        field 5: id (string)
+    """
     if not data:
-        return {"target_soc": None, "enabled_values": []}
+        return {"target_soc": None, "setting_type": 0}
 
     fields = _decode_message(data)
 
-    # enabledTargetSocValues may be packed (length-delimited repeated) or unpacked
-    enabled_values: list[int] = []
-    raw = fields.get(2, [])
-    for item in raw:
-        if isinstance(item, (bytes, bytearray)):
-            # Packed repeated varint
-            pos = 0
-            while pos < len(item):
-                val, pos = _decode_varint(item, pos)
-                enabled_values.append(val)
-        else:
-            enabled_values.append(item)
+    # Extract TargetSoc sub-message from field 3
+    target_soc_msg = _get_submessage(fields, 3)
+    pending_msg = _get_submessage(fields, 4)
+
+    target_soc = _get_int(target_soc_msg, 1, 0) if target_soc_msg else 0
+    setting_type = _get_int(target_soc_msg, 2, 0) if target_soc_msg else 0
+    pending_soc = _get_int(pending_msg, 1, 0) if pending_msg else 0
 
     return {
-        "target_soc": _get_int(fields, 1, 0) or None,
-        "enabled_values": enabled_values,
-        "setting_type": _get_int(fields, 3, 0),
-        "estimated_minutes": _get_int(fields, 4, 0),
-        "pending_target_soc": _get_int(fields, 5, 0) or None,
+        "target_soc": target_soc or None,
+        "setting_type": setting_type,
+        "pending_target_soc": pending_soc or None,
     }
 
 
@@ -196,32 +237,43 @@ class PccsClient:
     # -- Target SOC ----------------------------------------------------------
 
     def get_target_soc(self, vin: str) -> dict:
-        """Get the current charge target SOC for a vehicle."""
+        """Get the current charge target SOC for a vehicle.
+
+        GetTargetSoc is a server-streaming RPC; we take the first response.
+        """
         channel = self._get_channel()
-        method = channel.unary_unary(
+        method = channel.unary_stream(
             _METHOD_GET_TARGET_SOC,
             request_serializer=_identity_serialize,
             response_deserializer=_identity_deserialize,
         )
+        request = _build_get_request(vin)
         try:
-            response = method(b"", metadata=self._metadata(vin), timeout=30)
-            return _parse_target_soc_response(response)
+            responses = method(request, metadata=self._metadata(vin), timeout=30)
+            for response in responses:
+                return _parse_target_soc_response(response)
+            return _parse_target_soc_response(b"")
         except grpc.RpcError as err:
             _LOGGER.warning("PCCS GetTargetSoc failed: %s", err)
             raise
 
     def set_target_soc(self, vin: str, percentage: int) -> dict:
-        """Set the charge target SOC for a vehicle."""
+        """Set the charge target SOC for a vehicle.
+
+        SetTargetSoc is a server-streaming RPC; we take the first response.
+        """
         channel = self._get_channel()
-        method = channel.unary_unary(
+        method = channel.unary_stream(
             _METHOD_SET_TARGET_SOC,
             request_serializer=_identity_serialize,
             response_deserializer=_identity_deserialize,
         )
-        request = _build_set_target_soc_request(percentage)
+        request = _build_set_target_soc_request(vin, percentage)
         try:
-            response = method(request, metadata=self._metadata(vin), timeout=30)
-            return _parse_target_soc_response(response)
+            responses = method(request, metadata=self._metadata(vin), timeout=30)
+            for response in responses:
+                return _parse_target_soc_response(response)
+            return _parse_target_soc_response(b"")
         except grpc.RpcError as err:
             _LOGGER.warning("PCCS SetTargetSoc failed: %s", err)
             raise
@@ -240,8 +292,9 @@ class PccsClient:
             request_serializer=_identity_serialize,
             response_deserializer=_identity_deserialize,
         )
+        request = _build_get_request(vin)
         try:
-            responses = method(b"", metadata=self._metadata(vin), timeout=30)
+            responses = method(request, metadata=self._metadata(vin), timeout=30)
             for response in responses:
                 return _parse_charge_timer_response(response)
             # Empty stream
@@ -265,7 +318,7 @@ class PccsClient:
             request_serializer=_identity_serialize,
             response_deserializer=_identity_deserialize,
         )
-        request = _build_set_charge_timer_request(start_hour, start_min, end_hour, end_min)
+        request = _build_set_charge_timer_request(vin, start_hour, start_min, end_hour, end_min)
         try:
             response = method(request, metadata=self._metadata(vin), timeout=30)
             return _parse_charge_timer_response(response)

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -3,8 +3,8 @@
 Communicates with the PCCS gRPC API at api.pccs-prod.plstr.io for
 vehicle command-and-control operations (charge target, charge timer, etc.).
 
-Since we don't have compiled .proto stubs, we use grpc generic channel methods
-with manual protobuf wire-format encoding/decoding.
+Uses grpc generic channel methods with manual protobuf wire-format
+encoding/decoding (no compiled .proto stubs required).
 """
 
 from __future__ import annotations
@@ -42,27 +42,9 @@ _METHOD_SET_CHARGE_TIMER = f"{_SVC_CHARGE_TIMER}/SetGlobalChargeTimer"
 # ---------------------------------------------------------------------------
 # Protobuf message builders
 # ---------------------------------------------------------------------------
-# Protobuf field numbers for each message type.
-#
-# TargetSoc message:
-#   1: targetSoc (int32)
-#   2: enabledTargetSocValues (repeated int32)
-#   3: chargeTargetLevelSettingType (enum)
-#   4: chargingTimeEstimatedToTargetSocMinutes (int32)
-#   5: pendingTargetSoc (int32)
-#
-# GlobalChargeTimer message:
-#   1: startTime (TimeOfDay message)
-#   2: endTime (TimeOfDay message)
-#   3: departureTimeHours (int32)
-#   4: departureTimeMinutes (int32)
-#   5: isDepartureTimeActive (bool)
-#   6: isLocationChargeTimerActive (bool)
-#   7: pendingGlobalChargeTimer (message)
-#
-# TimeOfDay message:
-#   1: hours (int32)
-#   2: minutes (int32)
+# All PCCS requests wrap a ChronosRequest in field 1.
+# All PCCS responses wrap an envelope: field 1=id, field 2=vin, field 3=data.
+# See docstrings on _parse_*_response() for detailed field layouts.
 
 
 def _build_chronos_request(vin: str) -> bytes:

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -18,7 +18,6 @@ import grpc
 from .const import PCCS_API_HOST
 from .proto import (
     _decode_message,
-    _decode_varint,
     _encode_field_bytes,
     _encode_field_varint,
     _get_bool,
@@ -80,7 +79,7 @@ def _build_chronos_request(vin: str) -> bytes:
     msg += _encode_field_bytes(2, vin.encode("utf-8"))
     msg += _encode_field_bytes(3, b"RCS")
     # TimeZone message: field 1 = offsetMinutes (signed varint)
-    utc_offset = datetime.datetime.now(datetime.timezone.utc).astimezone().utcoffset()
+    utc_offset = datetime.datetime.now(datetime.UTC).astimezone().utcoffset()
     offset_minutes = int(utc_offset.total_seconds()) // 60
     # Proto3 int32: negative values need two's-complement encoding as uint64
     encoded_offset = offset_minutes if offset_minutes >= 0 else offset_minutes + (1 << 64)

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -163,7 +163,22 @@ def _parse_target_soc_response(data: bytes) -> dict:
 
 
 def _parse_charge_timer_response(data: bytes) -> dict:
-    """Parse GetGlobalChargeTimerStream / SetGlobalChargeTimer response."""
+    """Parse GetGlobalChargeTimerStream / SetGlobalChargeTimer response.
+
+    Response structure (GetGlobalChargeTimerResponse):
+        field 1: id (string)                     — echoed request ID
+        field 2: vin (string)                    — echoed VIN
+        field 3: globalChargeTimer (message)     — current timer data
+        field 4: pendingGlobalChargeTimer (message)
+
+    GlobalChargeTimer sub-message:
+        field 1: startTime (TimeOfDay message)
+        field 2: endTime (TimeOfDay message)
+        field 3: departureTimeHours (int32)
+        field 4: departureTimeMinutes (int32)
+        field 5: isDepartureTimeActive (bool)
+        field 6: isLocationChargeTimerActive (bool)
+    """
     if not data:
         return {
             "start_hour": None,
@@ -176,20 +191,34 @@ def _parse_charge_timer_response(data: bytes) -> dict:
             "is_location_timer_active": False,
         }
 
-    fields = _decode_message(data)
+    envelope = _decode_message(data)
 
-    start_time = _get_submessage(fields, 1)
-    end_time = _get_submessage(fields, 2)
+    # Extract GlobalChargeTimer sub-message from field 3 of the envelope
+    timer = _get_submessage(envelope, 3)
+    if not timer:
+        return {
+            "start_hour": None,
+            "start_min": None,
+            "end_hour": None,
+            "end_min": None,
+            "departure_hour": None,
+            "departure_min": None,
+            "is_departure_active": False,
+            "is_location_timer_active": False,
+        }
+
+    start_time = _get_submessage(timer, 1)
+    end_time = _get_submessage(timer, 2)
 
     return {
         "start_hour": _get_int(start_time, 1) if start_time else None,
         "start_min": _get_int(start_time, 2) if start_time else None,
         "end_hour": _get_int(end_time, 1) if end_time else None,
         "end_min": _get_int(end_time, 2) if end_time else None,
-        "departure_hour": _get_int(fields, 3, 0) or None,
-        "departure_min": _get_int(fields, 4, 0) or None,
-        "is_departure_active": _get_bool(fields, 5),
-        "is_location_timer_active": _get_bool(fields, 6),
+        "departure_hour": _get_int(timer, 3, 0) or None,
+        "departure_min": _get_int(timer, 4, 0) or None,
+        "is_departure_active": _get_bool(timer, 5),
+        "is_location_timer_active": _get_bool(timer, 6),
     }
 
 
@@ -311,17 +340,22 @@ class PccsClient:
         end_hour: int,
         end_min: int,
     ) -> dict:
-        """Set the global charge timer for a vehicle."""
+        """Set the global charge timer for a vehicle.
+
+        SetGlobalChargeTimer is a server-streaming RPC; we take the first response.
+        """
         channel = self._get_channel()
-        method = channel.unary_unary(
+        method = channel.unary_stream(
             _METHOD_SET_CHARGE_TIMER,
             request_serializer=_identity_serialize,
             response_deserializer=_identity_deserialize,
         )
         request = _build_set_charge_timer_request(vin, start_hour, start_min, end_hour, end_min)
         try:
-            response = method(request, metadata=self._metadata(vin), timeout=30)
-            return _parse_charge_timer_response(response)
+            responses = method(request, metadata=self._metadata(vin), timeout=30)
+            for response in responses:
+                return _parse_charge_timer_response(response)
+            return _parse_charge_timer_response(b"")
         except grpc.RpcError as err:
             _LOGGER.warning("PCCS SetGlobalChargeTimer failed: %s", err)
             raise

--- a/custom_components/polestar_soc/proto.py
+++ b/custom_components/polestar_soc/proto.py
@@ -1,7 +1,7 @@
 """Minimal protobuf wire-format helpers.
 
-Shared encoding/decoding utilities for gRPC clients that communicate
-without compiled .proto stubs.  Both pccs.py and cep.py import from here.
+Shared encoding/decoding utilities for gRPC clients (pccs.py and cep.py)
+using manual protobuf wire-format encoding instead of compiled .proto stubs.
 
 Wire types: 0=varint, 1=fixed64, 2=length-delimited, 5=fixed32
 """

--- a/custom_components/polestar_soc/strings.json
+++ b/custom_components/polestar_soc/strings.json
@@ -16,12 +16,20 @@
           "email": "Email",
           "password": "Password"
         }
+      },
+      "otp": {
+        "title": "Verification code",
+        "description": "A verification code has been sent to your Polestar ID email. Enter it below to enable charge limit and charge timer controls. You can leave this blank to skip \u2014 other sensors will still work.",
+        "data": {
+          "otp": "Verification code"
+        }
       }
     },
     "error": {
       "invalid_auth": "Invalid email or password.",
       "cannot_connect": "Could not connect to Polestar API.",
-      "no_vehicles": "No vehicles found on this account."
+      "no_vehicles": "No vehicles found on this account.",
+      "invalid_otp": "Invalid verification code. Please try again."
     },
     "abort": {
       "already_configured": "This account is already configured.",

--- a/custom_components/polestar_soc/translations/en.json
+++ b/custom_components/polestar_soc/translations/en.json
@@ -16,12 +16,20 @@
           "email": "Email",
           "password": "Password"
         }
+      },
+      "otp": {
+        "title": "Verification code",
+        "description": "A verification code has been sent to your Polestar ID email. Enter it below to enable charge limit and charge timer controls. You can leave this blank to skip \u2014 other sensors will still work.",
+        "data": {
+          "otp": "Verification code"
+        }
       }
     },
     "error": {
       "invalid_auth": "Invalid email or password.",
       "cannot_connect": "Could not connect to Polestar API.",
-      "no_vehicles": "No vehicles found on this account."
+      "no_vehicles": "No vehicles found on this account.",
+      "invalid_otp": "Invalid verification code. Please try again."
     },
     "abort": {
       "already_configured": "This account is already configured.",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,219 @@
+"""Tests for PolestarAPI two-phase login (login_start_2fa / login_complete_2fa)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.polestar_soc.coordinator import PolestarAPI
+
+# Fake HTML pages returned by the OIDC server during login flow.
+_AUTH_PAGE_HTML = '<form action="/as/abc123/resume/as/authorization.ping">login</form>'
+
+_CRED_REDIRECT_HEADERS = {"Location": "https://example.com/callback?code=AUTH_CODE_123"}
+
+_OTP_CHALLENGE_HTML = """
+<script>
+var globalContext = {
+    action: "/as/otp789/resume/as/authorization.ping"
+};
+</script>
+"""
+
+_OTP_SUCCESS_HTML = '<form id="otp-success-form" action="/as/otpdone/resume/as/authorization.ping">'
+
+_TOKEN_RESPONSE = {
+    "access_token": "pccs_access_tok",
+    "refresh_token": "pccs_refresh_tok",
+    "token_type": "Bearer",
+    "expires_in": 3600,
+}
+
+
+def _mock_get_auth_page(url, **kwargs):
+    """Mock the initial auth GET — returns a page with the resume URL."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = _AUTH_PAGE_HTML
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _mock_post_creds_redirect(url, **kwargs):
+    """Mock credential POST that returns 302 (no 2FA)."""
+    resp = MagicMock()
+    resp.status_code = 302
+    resp.headers = _CRED_REDIRECT_HEADERS
+    return resp
+
+
+def _mock_post_creds_otp_challenge(url, **kwargs):
+    """Mock credential POST that returns OTP challenge page (200)."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = _OTP_CHALLENGE_HTML
+    return resp
+
+
+def _mock_post_creds_auth_error(url, **kwargs):
+    """Mock credential POST that returns auth error."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = "ERR001: invalid credentials"
+    return resp
+
+
+def _mock_post_otp_success(url, **kwargs):
+    """Mock OTP submission that returns success form."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = _OTP_SUCCESS_HTML
+    return resp
+
+
+def _mock_post_continue_redirect(url, **kwargs):
+    """Mock the continue.authentication POST that redirects with code."""
+    resp = MagicMock()
+    resp.status_code = 302
+    resp.headers = {"Location": "polestar-explore://explore.polestar.com?code=PCCS_CODE"}
+    return resp
+
+
+def _mock_post_token_exchange(url, **kwargs):
+    """Mock the token exchange POST."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json = MagicMock(return_value=_TOKEN_RESPONSE)
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class TestLoginStart2fa:
+    """Tests for login_start_2fa."""
+
+    def test_returns_needs_otp_when_2fa_triggered(self):
+        """When the server challenges for OTP, return session state."""
+        api = PolestarAPI(client_id="test_client", redirect_uri="https://test/callback")
+
+        session_mock = MagicMock()
+        session_mock.get = _mock_get_auth_page
+        # Credential POST returns OTP challenge
+        session_mock.post = _mock_post_creds_otp_challenge
+
+        mock_path = "custom_components.polestar_soc.coordinator.requests.Session"
+        with patch(mock_path, return_value=session_mock):
+            result = api.login_start_2fa(
+                "user@test.com", "pass123", scope="openid", acr_values="2sv"
+            )
+
+        assert result["needs_otp"] is True
+        assert "_session_state" in result
+        state = result["_session_state"]
+        assert state["session"] is session_mock
+        assert "otp_resume" in state
+        assert "code_verifier" in state
+        assert "resume_url" in state
+
+    def test_returns_tokens_when_no_2fa(self):
+        """When the server doesn't challenge for 2FA, complete login directly."""
+        api = PolestarAPI(client_id="test_client", redirect_uri="https://test/callback")
+
+        session_mock = MagicMock()
+        session_mock.get = _mock_get_auth_page
+
+        call_count = 0
+
+        def post_side_effect(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Credential POST — redirect (no 2FA)
+                return _mock_post_creds_redirect(url, **kwargs)
+            # Token exchange
+            return _mock_post_token_exchange(url, **kwargs)
+
+        session_mock.post = post_side_effect
+
+        mock_path = "custom_components.polestar_soc.coordinator.requests.Session"
+        with patch(mock_path, return_value=session_mock):
+            result = api.login_start_2fa("user@test.com", "pass123")
+
+        assert "access_token" in result
+        assert result["access_token"] == "pccs_access_tok"
+        assert api.access_token == "pccs_access_tok"
+
+    def test_raises_on_invalid_credentials(self):
+        """Auth error response raises ConfigEntryAuthFailed."""
+        api = PolestarAPI(client_id="test_client", redirect_uri="https://test/callback")
+
+        session_mock = MagicMock()
+        session_mock.get = _mock_get_auth_page
+        session_mock.post = _mock_post_creds_auth_error
+
+        mock_path = "custom_components.polestar_soc.coordinator.requests.Session"
+        with (
+            patch(mock_path, return_value=session_mock),
+            pytest.raises(ConfigEntryAuthFailed),
+        ):
+            api.login_start_2fa("user@test.com", "wrong_pass")
+
+
+class TestLoginComplete2fa:
+    """Tests for login_complete_2fa."""
+
+    def test_submits_otp_and_returns_tokens(self):
+        """Happy path: OTP submitted, tokens returned."""
+        api = PolestarAPI(client_id="test_client", redirect_uri="https://test/callback")
+
+        session_mock = MagicMock()
+        call_count = 0
+
+        def post_side_effect(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # OTP submission
+                return _mock_post_otp_success(url, **kwargs)
+            if call_count == 2:
+                # Continue authentication redirect
+                return _mock_post_continue_redirect(url, **kwargs)
+            # Token exchange
+            return _mock_post_token_exchange(url, **kwargs)
+
+        session_mock.post = post_side_effect
+
+        session_state = {
+            "session": session_mock,
+            "otp_resume": "https://polestarid.eu.polestar.com/as/otp789/resume/as/authorization.ping",
+            "resume_url": "https://polestarid.eu.polestar.com/as/abc123/resume/as/authorization.ping",
+            "code_verifier": "test_verifier_123",
+        }
+
+        result = api.login_complete_2fa(session_state, "123456")
+        assert result["access_token"] == "pccs_access_tok"
+        assert api.access_token == "pccs_access_tok"
+
+    def test_raises_on_invalid_otp(self):
+        """Invalid OTP returns non-redirect status, raises UpdateFailed."""
+        api = PolestarAPI(client_id="test_client", redirect_uri="https://test/callback")
+
+        session_mock = MagicMock()
+
+        def post_side_effect(url, **kwargs):
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.text = "Invalid OTP code"
+            return resp
+
+        session_mock.post = post_side_effect
+
+        session_state = {
+            "session": session_mock,
+            "otp_resume": "https://example.com/otp",
+            "resume_url": "https://example.com/resume",
+            "code_verifier": "test_verifier",
+        }
+
+        with pytest.raises(UpdateFailed, match="2FA verification failed"):
+            api.login_complete_2fa(session_state, "wrong_code")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,210 @@
+"""Tests for the Polestar SOC config flow."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import ConfigEntryAuthFailed
+
+from custom_components.polestar_soc.config_flow import PolestarSOCConfigFlow
+
+_WEB_TOKENS = {
+    "access_token": "web_access_tok",
+    "refresh_token": "web_refresh_tok",
+}
+_PCCS_TOKENS = {
+    "access_token": "pccs_access_tok",
+    "refresh_token": "pccs_refresh_tok",
+}
+_VEHICLES = [{"vin": "TESTVIN123"}]
+
+
+def _mock_web_api():
+    """Create a mock PolestarAPI for web login."""
+    api = MagicMock()
+    api.login = MagicMock(return_value=_WEB_TOKENS)
+    api.get_vehicles = MagicMock(return_value=_VEHICLES)
+    return api
+
+
+def _mock_pccs_api_needs_otp():
+    """Create a mock PolestarAPI for PCCS that needs OTP."""
+    api = MagicMock()
+    api.login_start_2fa = MagicMock(return_value={
+        "needs_otp": True,
+        "_session_state": {
+            "session": MagicMock(),
+            "otp_resume": "url",
+            "resume_url": "url",
+            "code_verifier": "v",
+        },
+    })
+    api.login_complete_2fa = MagicMock(return_value=_PCCS_TOKENS)
+    return api
+
+
+def _mock_pccs_api_no_otp():
+    """Create a mock PolestarAPI for PCCS that doesn't need OTP."""
+    api = MagicMock()
+    api.login_start_2fa = MagicMock(return_value=_PCCS_TOKENS)
+    return api
+
+
+@pytest.fixture
+def flow(hass: HomeAssistant) -> PolestarSOCConfigFlow:
+    """Create a config flow instance with hass attached."""
+    f = PolestarSOCConfigFlow()
+    f.hass = hass
+    f.context = {"source": config_entries.SOURCE_USER}
+    return f
+
+
+class TestConfigFlowUser:
+    """Test the user (initial setup) config flow."""
+
+    @pytest.mark.usefixtures("hass")
+    async def test_full_flow_with_otp(self, hass: HomeAssistant, flow: PolestarSOCConfigFlow):
+        """Test the full happy path: credentials -> OTP -> entry created."""
+        web_api = _mock_web_api()
+        pccs_api = _mock_pccs_api_needs_otp()
+        pccs_api_complete = MagicMock()
+        pccs_api_complete.login_complete_2fa = MagicMock(return_value=_PCCS_TOKENS)
+
+        with patch(
+            "custom_components.polestar_soc.config_flow.PolestarAPI",
+            side_effect=[web_api, pccs_api, pccs_api_complete],
+        ):
+            # Step 1: submit credentials
+            result = await flow.async_step_user(
+                {"email": "test@polestar.com", "password": "secret"}
+            )
+            assert result["type"] is FlowResultType.FORM
+            assert result["step_id"] == "otp"
+
+            # Step 2: submit OTP
+            result = await flow.async_step_otp({"otp": "123456"})
+            assert result["type"] is FlowResultType.CREATE_ENTRY
+            assert result["title"] == "test@polestar.com"
+            assert result["data"]["access_token"] == "web_access_tok"
+            assert result["data"]["pccs_access_token"] == "pccs_access_tok"
+            assert result["data"]["pccs_refresh_token"] == "pccs_refresh_tok"
+
+    @pytest.mark.usefixtures("hass")
+    async def test_skip_otp(self, hass: HomeAssistant, flow: PolestarSOCConfigFlow):
+        """Test skipping OTP: entry created with web tokens only."""
+        web_api = _mock_web_api()
+        pccs_api = _mock_pccs_api_needs_otp()
+
+        with patch(
+            "custom_components.polestar_soc.config_flow.PolestarAPI",
+            side_effect=[web_api, pccs_api],
+        ):
+            result = await flow.async_step_user(
+                {"email": "test@polestar.com", "password": "secret"}
+            )
+            assert result["step_id"] == "otp"
+
+            # Submit blank OTP
+            result = await flow.async_step_otp({"otp": ""})
+            assert result["type"] is FlowResultType.CREATE_ENTRY
+            assert result["data"]["pccs_access_token"] is None
+            assert result["data"]["pccs_refresh_token"] is None
+
+    @pytest.mark.usefixtures("hass")
+    async def test_invalid_otp_shows_error(self, hass: HomeAssistant, flow: PolestarSOCConfigFlow):
+        """Test invalid OTP shows error and allows retry."""
+        web_api = _mock_web_api()
+        pccs_api_start = _mock_pccs_api_needs_otp()
+
+        pccs_api_bad = MagicMock()
+        pccs_api_bad.login_complete_2fa = MagicMock(
+            side_effect=Exception("2FA verification failed")
+        )
+
+        pccs_api_good = MagicMock()
+        pccs_api_good.login_complete_2fa = MagicMock(return_value=_PCCS_TOKENS)
+
+        with patch(
+            "custom_components.polestar_soc.config_flow.PolestarAPI",
+            side_effect=[web_api, pccs_api_start, pccs_api_bad, pccs_api_good],
+        ):
+            result = await flow.async_step_user(
+                {"email": "test@polestar.com", "password": "secret"}
+            )
+            assert result["step_id"] == "otp"
+
+            # Submit wrong OTP
+            result = await flow.async_step_otp({"otp": "wrong"})
+            assert result["type"] is FlowResultType.FORM
+            assert result["step_id"] == "otp"
+            assert result["errors"]["base"] == "invalid_otp"
+
+            # Retry with correct OTP
+            result = await flow.async_step_otp({"otp": "123456"})
+            assert result["type"] is FlowResultType.CREATE_ENTRY
+            assert result["data"]["pccs_access_token"] == "pccs_access_tok"
+
+    @pytest.mark.usefixtures("hass")
+    async def test_web_login_failure_no_otp_step(
+        self, hass: HomeAssistant, flow: PolestarSOCConfigFlow
+    ):
+        """Test that web login failure doesn't proceed to OTP step."""
+        web_api = MagicMock()
+        web_api.login = MagicMock(side_effect=ConfigEntryAuthFailed("bad creds"))
+
+        with patch(
+            "custom_components.polestar_soc.config_flow.PolestarAPI",
+            return_value=web_api,
+        ):
+            result = await flow.async_step_user(
+                {"email": "test@polestar.com", "password": "wrong"}
+            )
+            assert result["type"] is FlowResultType.FORM
+            assert result["step_id"] == "user"
+            assert result["errors"]["base"] == "invalid_auth"
+
+    @pytest.mark.usefixtures("hass")
+    async def test_pccs_2fa_failure_still_shows_otp_form(
+        self, hass: HomeAssistant, flow: PolestarSOCConfigFlow
+    ):
+        """Test that PCCS 2FA initiation failure still shows OTP form (user can skip)."""
+        web_api = _mock_web_api()
+        pccs_api = MagicMock()
+        pccs_api.login_start_2fa = MagicMock(side_effect=Exception("network error"))
+
+        with patch(
+            "custom_components.polestar_soc.config_flow.PolestarAPI",
+            side_effect=[web_api, pccs_api],
+        ):
+            result = await flow.async_step_user(
+                {"email": "test@polestar.com", "password": "secret"}
+            )
+            # Should show OTP form (with no session state)
+            assert result["step_id"] == "otp"
+
+            # Submit blank to skip
+            result = await flow.async_step_otp({"otp": ""})
+            assert result["type"] is FlowResultType.CREATE_ENTRY
+            assert result["data"]["access_token"] == "web_access_tok"
+            assert result["data"]["pccs_access_token"] is None
+
+    @pytest.mark.usefixtures("hass")
+    async def test_no_2fa_required_skips_otp_step(
+        self, hass: HomeAssistant, flow: PolestarSOCConfigFlow
+    ):
+        """Test that when PCCS doesn't require 2FA, OTP step is skipped."""
+        web_api = _mock_web_api()
+        pccs_api = _mock_pccs_api_no_otp()
+
+        with patch(
+            "custom_components.polestar_soc.config_flow.PolestarAPI",
+            side_effect=[web_api, pccs_api],
+        ):
+            result = await flow.async_step_user(
+                {"email": "test@polestar.com", "password": "secret"}
+            )
+            # Should create entry directly, skipping OTP
+            assert result["type"] is FlowResultType.CREATE_ENTRY
+            assert result["data"]["pccs_access_token"] == "pccs_access_tok"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -32,15 +32,17 @@ def _mock_web_api():
 def _mock_pccs_api_needs_otp():
     """Create a mock PolestarAPI for PCCS that needs OTP."""
     api = MagicMock()
-    api.login_start_2fa = MagicMock(return_value={
-        "needs_otp": True,
-        "_session_state": {
-            "session": MagicMock(),
-            "otp_resume": "url",
-            "resume_url": "url",
-            "code_verifier": "v",
-        },
-    })
+    api.login_start_2fa = MagicMock(
+        return_value={
+            "needs_otp": True,
+            "_session_state": {
+                "session": MagicMock(),
+                "otp_resume": "url",
+                "resume_url": "url",
+                "code_verifier": "v",
+            },
+        }
+    )
     api.login_complete_2fa = MagicMock(return_value=_PCCS_TOKENS)
     return api
 
@@ -158,9 +160,7 @@ class TestConfigFlowUser:
             "custom_components.polestar_soc.config_flow.PolestarAPI",
             return_value=web_api,
         ):
-            result = await flow.async_step_user(
-                {"email": "test@polestar.com", "password": "wrong"}
-            )
+            result = await flow.async_step_user({"email": "test@polestar.com", "password": "wrong"})
             assert result["type"] is FlowResultType.FORM
             assert result["step_id"] == "user"
             assert result["errors"]["base"] == "invalid_auth"

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -37,10 +37,12 @@ class TestServicePaths:
         assert _METHOD_SET_TARGET_SOC == "/pccs.chronos.services.v1.TargetSocService/SetTargetSoc"
 
     def test_charge_timer_get_path(self):
-        assert _METHOD_GET_CHARGE_TIMER == "/pccs.chronos.services.v2.GlobalChargeTimerService/GetGlobalChargeTimerStream"
+        expected = "/pccs.chronos.services.v2.GlobalChargeTimerService/GetGlobalChargeTimerStream"
+        assert expected == _METHOD_GET_CHARGE_TIMER
 
     def test_charge_timer_set_path(self):
-        assert _METHOD_SET_CHARGE_TIMER == "/pccs.chronos.services.v2.GlobalChargeTimerService/SetGlobalChargeTimer"
+        expected = "/pccs.chronos.services.v2.GlobalChargeTimerService/SetGlobalChargeTimer"
+        assert expected == _METHOD_SET_CHARGE_TIMER
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -3,6 +3,10 @@
 import pytest
 
 from custom_components.polestar_soc.pccs import (
+    _METHOD_GET_CHARGE_TIMER,
+    _METHOD_GET_TARGET_SOC,
+    _METHOD_SET_CHARGE_TIMER,
+    _METHOD_SET_TARGET_SOC,
     _build_set_charge_timer_request,
     _build_set_target_soc_request,
     _build_time_of_day,
@@ -19,6 +23,25 @@ from custom_components.polestar_soc.proto import (
     _get_int,
     _get_submessage,
 )
+
+# ---------------------------------------------------------------------------
+# Service path constants — must include the pccs. package prefix
+# ---------------------------------------------------------------------------
+
+
+class TestServicePaths:
+    def test_target_soc_get_path(self):
+        assert _METHOD_GET_TARGET_SOC == "/pccs.chronos.services.v1.TargetSocService/GetTargetSoc"
+
+    def test_target_soc_set_path(self):
+        assert _METHOD_SET_TARGET_SOC == "/pccs.chronos.services.v1.TargetSocService/SetTargetSoc"
+
+    def test_charge_timer_get_path(self):
+        assert _METHOD_GET_CHARGE_TIMER == "/pccs.chronos.services.v2.GlobalChargeTimerService/GetGlobalChargeTimerStream"
+
+    def test_charge_timer_set_path(self):
+        assert _METHOD_SET_CHARGE_TIMER == "/pccs.chronos.services.v2.GlobalChargeTimerService/SetGlobalChargeTimer"
+
 
 # ---------------------------------------------------------------------------
 # Varint encoding / decoding
@@ -187,9 +210,12 @@ class TestGetSubmessage:
 
 class TestBuildSetTargetSocRequest:
     def test_roundtrip(self):
-        data = _build_set_target_soc_request(80)
+        data = _build_set_target_soc_request("TESTVIN123", 80)
         fields = _decode_message(data)
-        assert fields[1] == [80]
+        # Field 1 is the ChronosRequest sub-message
+        assert 1 in fields
+        # Field 2 is the target SOC value
+        assert fields[2] == [80]
 
 
 class TestBuildTimeOfDay:
@@ -215,11 +241,12 @@ class TestBuildTimeOfDay:
 
 class TestBuildSetChargeTimerRequest:
     def test_has_start_and_end(self):
-        data = _build_set_charge_timer_request(22, 0, 6, 30)
+        data = _build_set_charge_timer_request("TESTVIN123", 22, 0, 6, 30)
         fields = _decode_message(data)
-        # Fields 1 and 2 should be length-delimited sub-messages
+        # Field 1 is ChronosRequest, 2 is start time, 3 is end time
         assert 1 in fields
         assert 2 in fields
+        assert 3 in fields
 
 
 # ---------------------------------------------------------------------------
@@ -231,26 +258,25 @@ class TestParseTargetSocResponse:
     def test_empty_data(self):
         result = _parse_target_soc_response(b"")
         assert result["target_soc"] is None
-        assert result["enabled_values"] == []
+        assert result["setting_type"] == 0
 
     def test_basic_response(self):
-        # Encode: field 1 = 80 (target_soc)
-        data = _encode_field_varint(1, 80)
+        # Build a response with TargetSoc sub-message in field 3
+        # TargetSoc: field 1 = 80 (batteryChargeTargetLevel), field 2 = 3 (CUSTOM)
+        inner = _encode_field_varint(1, 80) + _encode_field_varint(2, 3)
+        data = _encode_field_bytes(3, inner)
         result = _parse_target_soc_response(data)
         assert result["target_soc"] == 80
+        assert result["setting_type"] == 3
 
-    def test_with_packed_enabled_values(self):
-        # Build a response with target_soc=80 and packed enabled_values
-        target = _encode_field_varint(1, 80)
-        # Pack values 50, 60, 70, 80, 90, 100 as length-delimited repeated varint
-        packed = b""
-        for v in [50, 60, 70, 80, 90, 100]:
-            packed += _encode_varint(v)
-        enabled = _encode_field_bytes(2, packed)
-        data = target + enabled
+    def test_with_pending(self):
+        # Build response with both current and pending target SOC
+        inner = _encode_field_varint(1, 80) + _encode_field_varint(2, 3)
+        pending = _encode_field_varint(1, 90)
+        data = _encode_field_bytes(3, inner) + _encode_field_bytes(4, pending)
         result = _parse_target_soc_response(data)
         assert result["target_soc"] == 80
-        assert result["enabled_values"] == [50, 60, 70, 80, 90, 100]
+        assert result["pending_target_soc"] == 90
 
 
 class TestParseChargeTimerResponse:

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -286,10 +286,20 @@ class TestParseChargeTimerResponse:
         assert result["end_hour"] is None
         assert result["is_departure_active"] is False
 
+    def test_no_timer_in_envelope(self):
+        # Envelope with id and vin but no timer sub-message in field 3
+        data = _encode_field_bytes(1, b"some-id") + _encode_field_bytes(2, b"VIN123")
+        result = _parse_charge_timer_response(data)
+        assert result["start_hour"] is None
+        assert result["end_hour"] is None
+
     def test_with_times(self):
+        # Build GlobalChargeTimer sub-message: field 1=start, field 2=end
         start = _build_time_of_day(22, 30)
         end = _build_time_of_day(6, 0)
-        data = _encode_field_bytes(1, start) + _encode_field_bytes(2, end)
+        timer = _encode_field_bytes(1, start) + _encode_field_bytes(2, end)
+        # Wrap in response envelope: field 3 = globalChargeTimer
+        data = _encode_field_bytes(3, timer)
         result = _parse_charge_timer_response(data)
         assert result["start_hour"] == 22
         assert result["start_min"] == 30

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -216,6 +216,8 @@ class TestBuildSetTargetSocRequest:
         fields = _decode_message(data)
         # Field 1 is the ChronosRequest sub-message
         assert 1 in fields
+        chronos = _decode_message(fields[1][0])
+        assert chronos[2] == [b"TESTVIN123"]
         # Field 2 is the target SOC value
         assert fields[2] == [80]
 


### PR DESCRIPTION
## Summary
- Fix PCCS gRPC: correct service paths, request format (ChronosRequest wrapper), and streaming RPCs
- Add 2FA/OTP step to config flow so PCCS tokens are obtained during setup
- Simplify PCCS token refresh — only attempt refresh, no background re-login
- Isolate PCCS failures from web API sensors

## Test plan
- [ ] Verify PCCS target SOC and charge timer read correctly
- [ ] Verify OTP config flow completes successfully
- [ ] Verify skipping OTP still sets up basic sensors