### PR TITLE
Fix battery field mapping and charge timer parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Polestar Home Assistant Integration
+
+Custom Home Assistant integration for Polestar vehicles. Provides battery, charging, climate, and range sensors via the Polestar and Volvo cloud APIs.
+
+## Features
+
+### Sensors
+
+| Sensor | Unit | Description |
+|--------|------|-------------|
+| Battery SOC | % | Battery state of charge |
+| Charging Status | — | Charging / Idle / Fully charged / Scheduled / Fault |
+| Charging Time Remaining | min | Estimated time to full charge |
+| Estimated Range | km | Estimated remaining range |
+| Odometer | km | Total distance driven |
+| Climate Status | — | Off / Pre-conditioning / Starting / Residual heat |
+| Driver Seat Heating | — | Off / Low / Medium / High |
+| Passenger Seat Heating | — | Off / Low / Medium / High |
+| Rear Left Seat Heating | — | Off / Low / Medium / High |
+| Rear Right Seat Heating | — | Off / Low / Medium / High |
+| Steering Wheel Heating | — | Off / Low / Medium / High |
+
+### Controls
+
+| Entity | Type | Description |
+|--------|------|-------------|
+| Charge Limit | Number (50–100%, step 5) | Target state of charge slider |
+| Charging Start Time | Time | Scheduled charging start time |
+| Charging End Time | Time | Scheduled charging end time |
+
+## Installation
+
+1. Copy `custom_components/polestar_soc/` into your Home Assistant `custom_components/` directory.
+2. Restart Home Assistant.
+3. Go to **Settings > Devices & Services > Add Integration** and search for **Polestar State of Charge**.
+4. Enter your Polestar ID email and password.
+5. If prompted, enter the OTP code sent to your email (required for charge limit control).
+
+## Configuration
+
+The integration authenticates using Polestar ID OAuth2. A second authentication step (email OTP) is offered during setup to enable charge limit and charge timer controls. This step is optional — sensors work without it.
+
+Data is polled every 5 minutes.
+
+## Development
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+pytest
+```

--- a/custom_components/polestar_soc/cep.py
+++ b/custom_components/polestar_soc/cep.py
@@ -36,6 +36,9 @@ _METHOD_GET_CLIMATE = (
 )
 _METHOD_GET_BATTERY = "/services.vehiclestates.battery.BatteryService/GetLatestBattery"
 
+# BatteryState field numbers captured in raw_fields for debugging.
+_RAW_BATTERY_FIELD_NUMBERS = (5, 7, 8, 17, 26, 28)
+
 
 # ---------------------------------------------------------------------------
 # Request builders
@@ -75,27 +78,21 @@ def _parse_climate_response(data: bytes) -> dict:
 
     Two-level decode: outer envelope has field 3 = state sub-message.
     """
+    empty = {
+        "status": None,
+        "driver_seat_heating": None,
+        "passenger_seat_heating": None,
+        "rear_left_seat_heating": None,
+        "rear_right_seat_heating": None,
+        "steering_wheel_heating": None,
+    }
     if not data:
-        return {
-            "status": None,
-            "driver_seat_heating": None,
-            "passenger_seat_heating": None,
-            "rear_left_seat_heating": None,
-            "rear_right_seat_heating": None,
-            "steering_wheel_heating": None,
-        }
+        return empty
 
     outer = _decode_message(data)
     state = _get_submessage(outer, 3)
     if state is None:
-        return {
-            "status": None,
-            "driver_seat_heating": None,
-            "passenger_seat_heating": None,
-            "rear_left_seat_heating": None,
-            "rear_right_seat_heating": None,
-            "steering_wheel_heating": None,
-        }
+        return empty
 
     return {
         "status": _format_climate_status(_get_int(state, 2, 0)),
@@ -111,31 +108,55 @@ def _parse_battery_response(data: bytes) -> dict:
     """Parse GetLatestBattery response.
 
     Two-level decode: outer envelope has field 3 = battery state sub-message.
-    SOC and charging_power are IEEE 754 doubles (wire type 1 / fixed64).
+
+    Field mapping (BatteryState proto):
+        field 2:  battery_charge_level_percentage (double)
+        field 3:  average_energy_consumption_kwh_per_100_km (double)
+        field 4:  estimated_distance_to_empty_km (varint)
+        field 5:  estimated_charging_time_to_full_minutes (varint)
+        field 6:  charger_connection_status (enum: 1=CONNECTED, 2=DISCONNECTED, 3=FAULT)
+        field 7:  charging_status (enum: 1=CHARGING, 2=IDLE, 3=SCHEDULED, ...)
+        field 8:  estimated_distance_to_empty_miles (varint)
+        field 10: charging_power_watts (varint)
+        field 17: charging_type (enum)
+        field 26: charger_power_status (enum)
+        field 28: unknown (CEP-specific?)
     """
+    empty = {
+        "soc": None,
+        "estimated_range_km": None,
+        "charger_connection_status": None,
+        "charging_status": None,
+        "avg_energy_consumption_kwh_per_100km": None,
+        "estimated_charging_time_minutes": None,
+        "estimated_range_miles": None,
+        "charging_power_watts": None,
+        "raw_fields": {},
+    }
     if not data:
-        return {
-            "soc": None,
-            "estimated_range_km": None,
-            "charging_status": None,
-            "charging_power_kw": None,
-        }
+        return empty
 
     outer = _decode_message(data)
     state = _get_submessage(outer, 3)
     if state is None:
-        return {
-            "soc": None,
-            "estimated_range_km": None,
-            "charging_status": None,
-            "charging_power_kw": None,
-        }
+        return empty
+
+    raw_fields = {}
+    for fn in _RAW_BATTERY_FIELD_NUMBERS:
+        vals = state.get(fn)
+        if vals is not None:
+            raw_fields[fn] = vals[0]
 
     return {
         "soc": _get_double(state, 2),
         "estimated_range_km": _get_int(state, 4) or None,
-        "charging_status": _get_int(state, 6) or None,
-        "charging_power_kw": _get_double(state, 3),
+        "charger_connection_status": _get_int(state, 6) or None,
+        "charging_status": _get_int(state, 7) or None,
+        "avg_energy_consumption_kwh_per_100km": _get_double(state, 3),
+        "estimated_charging_time_minutes": _get_int(state, 5) or None,
+        "estimated_range_miles": _get_int(state, 8) or None,
+        "charging_power_watts": _get_int(state, 10) or None,
+        "raw_fields": raw_fields,
     }
 
 

--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -417,7 +417,8 @@ class PolestarCoordinator(DataUpdateCoordinator):
         self.api.access_token = entry.data.get("access_token")
         self.api.refresh_token = entry.data.get("refresh_token")
 
-        # Separate API instance for PCCS (needs PCCS client_id)
+        # PCCS API instance kept for potential future write operations
+        # that may require the PCCS token with 2FA scope.
         self._pccs_api = PolestarAPI(
             client_id=PCCS_CLIENT_ID,
             redirect_uri=PCCS_REDIRECT_URI,
@@ -425,7 +426,8 @@ class PolestarCoordinator(DataUpdateCoordinator):
         self._pccs_api.access_token = entry.data.get("pccs_access_token")
         self._pccs_api.refresh_token = entry.data.get("pccs_refresh_token")
 
-        self.pccs = PccsClient(self._pccs_api.access_token or "")
+        # PCCS chronos services (charge timer, target SOC) accept the web token
+        self.pccs = PccsClient(self.api.access_token or "")
         self.cep = CepClient(self.api.access_token or "")
         self._email: str = entry.data["email"]
         self._password: str = entry.data["password"]
@@ -578,8 +580,8 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 "pccs_refresh_token": self._pccs_api.refresh_token,
             },
         )
-        # Keep gRPC client tokens in sync
-        self.pccs.access_token = self._pccs_api.access_token or ""
+        # Keep gRPC client tokens in sync (both use web token)
+        self.pccs.access_token = self.api.access_token or ""
         self.cep.access_token = self.api.access_token or ""
 
     def close(self) -> None:

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -43,8 +43,7 @@ _METHOD_SET_CHARGE_TIMER = f"{_SVC_CHARGE_TIMER}/SetGlobalChargeTimer"
 # Protobuf message builders
 # ---------------------------------------------------------------------------
 # All PCCS requests wrap a ChronosRequest in field 1.
-# All PCCS responses wrap an envelope: field 1=id, field 2=vin, field 3=data.
-# See docstrings on _parse_*_response() for detailed field layouts.
+# Response envelope layouts vary by RPC — see docstrings on _parse_*_response().
 
 
 def _build_chronos_request(vin: str) -> bytes:
@@ -146,47 +145,32 @@ def _parse_target_soc_response(data: bytes) -> dict:
 def _parse_charge_timer_response(data: bytes) -> dict:
     """Parse GetGlobalChargeTimerStream / SetGlobalChargeTimer response.
 
-    Response structure (GetGlobalChargeTimerResponse):
-        field 1: id (string)                     — echoed request ID
-        field 2: vin (string)                    — echoed VIN
-        field 3: globalChargeTimer (message)     — current timer data
-        field 4: pendingGlobalChargeTimer (message)
+    Response structure (verified against live API 2026-03-11):
+        field 1: globalChargeTimer (message)     — current timer data
+        field 3: updatedAt (varint)              — server timestamp
 
     GlobalChargeTimer sub-message:
-        field 1: startTime (TimeOfDay message)
-        field 2: endTime (TimeOfDay message)
-        field 3: departureTimeHours (int32)
-        field 4: departureTimeMinutes (int32)
-        field 5: isDepartureTimeActive (bool)
-        field 6: isLocationChargeTimerActive (bool)
+        field 1: startTime (TimeOfDay message)   — {1: hours, 2: minutes, 3: tz}
+        field 2: endTime (TimeOfDay message)     — {1: hours, 2: minutes, 3: tz}
+        field 3: isDepartureTimeActive (bool)
+        field 4: metadata (message)              — {1: id, 2: timestamp, 3: source}
     """
+    empty = {
+        "start_hour": None,
+        "start_min": None,
+        "end_hour": None,
+        "end_min": None,
+        "is_departure_active": False,
+    }
     if not data:
-        return {
-            "start_hour": None,
-            "start_min": None,
-            "end_hour": None,
-            "end_min": None,
-            "departure_hour": None,
-            "departure_min": None,
-            "is_departure_active": False,
-            "is_location_timer_active": False,
-        }
+        return empty
 
     envelope = _decode_message(data)
 
-    # Extract GlobalChargeTimer sub-message from field 3 of the envelope
-    timer = _get_submessage(envelope, 3)
+    # GlobalChargeTimer is in field 1 of the response envelope
+    timer = _get_submessage(envelope, 1)
     if not timer:
-        return {
-            "start_hour": None,
-            "start_min": None,
-            "end_hour": None,
-            "end_min": None,
-            "departure_hour": None,
-            "departure_min": None,
-            "is_departure_active": False,
-            "is_location_timer_active": False,
-        }
+        return empty
 
     start_time = _get_submessage(timer, 1)
     end_time = _get_submessage(timer, 2)
@@ -196,10 +180,7 @@ def _parse_charge_timer_response(data: bytes) -> dict:
         "start_min": _get_int(start_time, 2) if start_time else None,
         "end_hour": _get_int(end_time, 1) if end_time else None,
         "end_min": _get_int(end_time, 2) if end_time else None,
-        "departure_hour": _get_int(timer, 3, 0) or None,
-        "departure_min": _get_int(timer, 4, 0) or None,
-        "is_departure_active": _get_bool(timer, 5),
-        "is_location_timer_active": _get_bool(timer, 6),
+        "is_departure_active": _get_bool(timer, 3),
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,8 +60,13 @@ def sample_cep_battery():
     return {
         "soc": 76.0,
         "estimated_range_km": 230,
+        "charger_connection_status": 2,
         "charging_status": 2,
-        "charging_power_kw": 2.9,
+        "avg_energy_consumption_kwh_per_100km": 2.9,
+        "estimated_charging_time_minutes": None,
+        "estimated_range_miles": 140,
+        "charging_power_watts": None,
+        "raw_fields": {},
     }
 
 

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -24,10 +24,13 @@ CLIMATE_PAYLOAD = bytes.fromhex(
     "10021800300348005000580060006800"
 )
 
-# Battery: SOC=76.0, charging_power=2.9, range=230, charging_status=2
+# Battery: SOC=76.0, avg_consumption=2.9, range=230km/140mi,
+# charger_connection=2(DISCONNECTED), charging_status=2(IDLE),
+# est_charging_time=0, charging_type=1, charger_power_status=1, field28=5
 BATTERY_PAYLOAD = bytes.fromhex(
-    "121159534d594b4541453152423030303030311a2c0a0c08b0dcb6cd0610808c8d9e02"
+    "121159534d594b4541453152423030303030311a350a0c08b0dcb6cd0610808c8d9e02"
     "11000000000000534019333333333333074020e601280030023802408c01"
+    "880101d00101e00105"
 )
 
 TEST_VIN = "YSMYKEAE1RB000001"
@@ -89,15 +92,32 @@ class TestParseBatteryResponse:
         result = _parse_battery_response(BATTERY_PAYLOAD)
         assert result["soc"] == pytest.approx(76.0)
         assert result["estimated_range_km"] == 230
-        assert result["charging_power_kw"] == pytest.approx(2.9, abs=0.1)
-        assert result["charging_status"] == 2
+        assert result["avg_energy_consumption_kwh_per_100km"] == pytest.approx(2.9, abs=0.1)
+        assert result["charger_connection_status"] == 2  # DISCONNECTED
+        assert result["charging_status"] == 2  # IDLE (from field 7)
+        assert result["estimated_charging_time_minutes"] is None  # field 5 = 0
+        assert result["estimated_range_miles"] == 140
+        assert result["charging_power_watts"] is None  # field 10 not in payload
+
+    def test_raw_fields(self):
+        result = _parse_battery_response(BATTERY_PAYLOAD)
+        raw = result["raw_fields"]
+        assert set(raw.keys()) == {5, 7, 8, 17, 26, 28}
+        assert raw[5] == 0   # estimated_charging_time_to_full_minutes
+        assert raw[7] == 2   # charging_status (IDLE)
+        assert raw[8] == 140  # estimated_distance_to_empty_miles
+        assert raw[17] == 1  # charging_type
+        assert raw[26] == 1  # charger_power_status
+        assert raw[28] == 5  # unknown CEP-specific field
 
     def test_empty_response(self):
         result = _parse_battery_response(b"")
         assert result["soc"] is None
         assert result["estimated_range_km"] is None
         assert result["charging_status"] is None
-        assert result["charging_power_kw"] is None
+        assert result["charger_connection_status"] is None
+        assert result["charging_power_watts"] is None
+        assert result["raw_fields"] == {}
 
     def test_two_level_decode(self):
         """Verify outer envelope field 3 contains battery state."""
@@ -116,6 +136,7 @@ class TestParseBatteryResponse:
         result = _parse_battery_response(data)
         assert result["soc"] is None
         assert result["estimated_range_km"] is None
+        assert result["raw_fields"] == {}
 
 
 class TestFormatClimateStatus:

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -103,8 +103,8 @@ class TestParseBatteryResponse:
         result = _parse_battery_response(BATTERY_PAYLOAD)
         raw = result["raw_fields"]
         assert set(raw.keys()) == {5, 7, 8, 17, 26, 28}
-        assert raw[5] == 0   # estimated_charging_time_to_full_minutes
-        assert raw[7] == 2   # charging_status (IDLE)
+        assert raw[5] == 0  # estimated_charging_time_to_full_minutes
+        assert raw[7] == 2  # charging_status (IDLE)
         assert raw[8] == 140  # estimated_distance_to_empty_miles
         assert raw[17] == 1  # charging_type
         assert raw[26] == 1  # charger_power_status

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -291,8 +291,8 @@ class TestParseChargeTimerResponse:
         assert result["is_departure_active"] is False
 
     def test_no_timer_in_envelope(self):
-        # Envelope with id and vin but no timer sub-message in field 3
-        data = _encode_field_bytes(1, b"some-id") + _encode_field_bytes(2, b"VIN123")
+        # Envelope with only a timestamp in field 3 but no timer in field 1
+        data = _encode_field_varint(3, 1773247754487)
         result = _parse_charge_timer_response(data)
         assert result["start_hour"] is None
         assert result["end_hour"] is None
@@ -302,10 +302,26 @@ class TestParseChargeTimerResponse:
         start = _build_time_of_day(22, 30)
         end = _build_time_of_day(6, 0)
         timer = _encode_field_bytes(1, start) + _encode_field_bytes(2, end)
-        # Wrap in response envelope: field 3 = globalChargeTimer
-        data = _encode_field_bytes(3, timer)
+        # Wrap in response envelope: field 1 = globalChargeTimer
+        data = _encode_field_bytes(1, timer)
         result = _parse_charge_timer_response(data)
         assert result["start_hour"] == 22
         assert result["start_min"] == 30
         assert result["end_hour"] == 6
         assert result["end_min"] == 0
+        assert result["is_departure_active"] is False
+
+    def test_with_timezone_in_time_of_day(self):
+        """TimeOfDay may include a timezone sub-message in field 3."""
+        # Build TimeOfDay with extra field 3 (timezone offset sub-message)
+        tz_submsg = _encode_field_varint(1, 120)  # UTC+2 offset in minutes
+        start = _build_time_of_day(23, 15) + _encode_field_bytes(3, tz_submsg)
+        end = _build_time_of_day(7, 0) + _encode_field_bytes(3, tz_submsg)
+        timer = _encode_field_bytes(1, start) + _encode_field_bytes(2, end)
+        data = _encode_field_bytes(1, timer)
+        result = _parse_charge_timer_response(data)
+        assert result["start_hour"] == 23
+        assert result["start_min"] == 15
+        assert result["end_hour"] == 7
+        assert result["end_min"] == 0
+        assert result["is_departure_active"] is False


### PR DESCRIPTION
## Summary

- **Fix battery field labels** in CEP parser — field 3 is `avg_energy_consumption_kwh_per_100km` (was `charging_power_kw`), field 6 is `charger_connection_status` (was `charging_status`), field 7 is the actual `charging_status`. Adds fields 5, 8, 10 and a `raw_fields` diagnostic dict.
- **Fix charge timer response parser** — GlobalChargeTimer data lives in field 1 of the response envelope, not field 3. This was the root cause of charge timer reads returning all nulls.
- **Use web client token for PCCS chronos services** (charge timer, target SOC) — the PCCS chronos gRPC services accept the standard web token, removing the need for 2FA on read-only operations.

## Test plan

- [x] All 116 unit tests pass
- [x] Battery parser correctly extracts all fields from test payloads
- [x] Charge timer parser correctly decodes start/end times including timezone sub-messages
- [x] Coordinator uses web token for PccsClient
- [x] Verified against live API