### PR TITLE
Add vehicle location device tracker via CEP gRPC API

### DIFF
--- a/custom_components/polestar_soc/__init__.py
+++ b/custom_components/polestar_soc/__init__.py
@@ -9,7 +9,12 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 from .coordinator import PolestarCoordinator
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.NUMBER, Platform.TIME]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.NUMBER,
+    Platform.TIME,
+    Platform.DEVICE_TRACKER,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/polestar_soc/cep.py
+++ b/custom_components/polestar_soc/cep.py
@@ -35,6 +35,7 @@ _METHOD_GET_CLIMATE = (
     ".ParkingClimatizationService/GetLatestParkingClimatization"
 )
 _METHOD_GET_BATTERY = "/services.vehiclestates.battery.BatteryService/GetLatestBattery"
+_METHOD_GET_LOCATION = "/dtlinternet.DtlInternetService/GetLastKnownLocation"
 
 # BatteryState field numbers captured in raw_fields for debugging.
 _RAW_BATTERY_FIELD_NUMBERS = (5, 7, 8, 17, 26, 28)
@@ -48,6 +49,11 @@ _RAW_BATTERY_FIELD_NUMBERS = (5, 7, 8, 17, 26, 28)
 def _build_vin_request(vin: str) -> bytes:
     """Build a request with VIN as field 2 (string)."""
     return _encode_field_bytes(2, vin.encode("utf-8"))
+
+
+def _build_location_request(vin: str) -> bytes:
+    """Build a request with VIN as field 1 (DtlInternetService uses field 1, not field 2)."""
+    return _encode_field_bytes(1, vin.encode("utf-8"))
 
 
 # ---------------------------------------------------------------------------
@@ -160,6 +166,33 @@ def _parse_battery_response(data: bytes) -> dict:
     }
 
 
+def _parse_location_response(data: bytes) -> dict:
+    """Parse GetLastKnownLocation response.
+
+    Unlike climate/battery, location fields are at the top level (no envelope).
+    Field mapping:
+        field 1 (string): VIN
+        field 2 (double): longitude
+        field 3 (double): latitude
+        field 4 (varint): timestamp_ms (milliseconds since epoch)
+    """
+    empty: dict = {"latitude": None, "longitude": None, "timestamp_ms": None}
+    if not data:
+        return empty
+
+    fields = _decode_message(data)
+    latitude = _get_double(fields, 3)
+    longitude = _get_double(fields, 2)
+    if latitude is None or longitude is None:
+        return empty
+
+    return {
+        "latitude": latitude,
+        "longitude": longitude,
+        "timestamp_ms": _get_int(fields, 4) or None,
+    }
+
+
 # ---------------------------------------------------------------------------
 # CepClient
 # ---------------------------------------------------------------------------
@@ -225,4 +258,21 @@ class CepClient:
             return _parse_battery_response(response)
         except grpc.RpcError as err:
             _LOGGER.warning("CEP GetLatestBattery failed: %s", err)
+            raise
+
+    def get_location(self, vin: str) -> dict:
+        """Get last known vehicle location."""
+        channel = self._get_channel()
+        method = channel.unary_unary(
+            _METHOD_GET_LOCATION,
+            request_serializer=_identity_serialize,
+            response_deserializer=_identity_deserialize,
+        )
+        try:
+            response = method(
+                _build_location_request(vin), metadata=self._metadata(vin), timeout=30
+            )
+            return _parse_location_response(response)
+        except grpc.RpcError as err:
+            _LOGGER.warning("CEP GetLastKnownLocation failed: %s", err)
             raise

--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -515,6 +515,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
                     "charge_timer": {},
                     "climate": {},
                     "cep_battery": {},
+                    "location": {},
                 }
 
             vins = [v["vin"] for v in vehicles]
@@ -543,9 +544,10 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 except Exception:
                     _LOGGER.debug("Failed to fetch PCCS charge timer for %s", vin)
 
-            # Fetch CEP data (climate status + battery) per VIN
+            # Fetch CEP data (climate status + battery + location) per VIN
             climate_by_vin: dict = {}
             cep_battery_by_vin: dict = {}
+            location_by_vin: dict = {}
             for vin in vins:
                 try:
                     climate_by_vin[vin] = self.cep.get_parking_climatization(vin)
@@ -555,6 +557,10 @@ class PolestarCoordinator(DataUpdateCoordinator):
                     cep_battery_by_vin[vin] = self.cep.get_battery(vin)
                 except Exception:
                     _LOGGER.debug("Failed to fetch CEP battery for %s", vin)
+                try:
+                    location_by_vin[vin] = self.cep.get_location(vin)
+                except Exception:
+                    _LOGGER.debug("Failed to fetch CEP location for %s", vin)
 
             return {
                 "vehicles": vehicles,
@@ -564,6 +570,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 "charge_timer": charge_timer_by_vin,
                 "climate": climate_by_vin,
                 "cep_battery": cep_battery_by_vin,
+                "location": location_by_vin,
             }
 
         return await self.hass.async_add_executor_job(_do_fetch)

--- a/custom_components/polestar_soc/device_tracker.py
+++ b/custom_components/polestar_soc/device_tracker.py
@@ -1,0 +1,102 @@
+"""Device tracker platform for Polestar — vehicle GPS location."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from homeassistant.components.device_tracker import SourceType
+from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import PolestarCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Polestar device tracker from a config entry."""
+    coordinator: PolestarCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities: list[PolestarDeviceTracker] = []
+    for vehicle in coordinator.data.get("vehicles", []):
+        vin = vehicle["vin"]
+        entities.append(PolestarDeviceTracker(coordinator, vehicle, vin))
+
+    async_add_entities(entities)
+
+
+class PolestarDeviceTracker(CoordinatorEntity[PolestarCoordinator], TrackerEntity):
+    """Representation of a Polestar vehicle location."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "location"
+    _attr_source_type = SourceType.GPS
+
+    def __init__(
+        self,
+        coordinator: PolestarCoordinator,
+        vehicle: dict,
+        vin: str,
+    ) -> None:
+        """Initialize the device tracker."""
+        super().__init__(coordinator)
+        self._vin = vin
+        self._attr_unique_id = f"{vin}_location"
+
+        model_name = "Polestar"
+        content = vehicle.get("content")
+        if content and content.get("model"):
+            model_name = content["model"].get("name", model_name)
+        year = vehicle.get("modelYear", "")
+        device_name = f"{model_name} ({year})" if year else model_name
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vin)},
+            name=device_name,
+            manufacturer="Polestar",
+            model=model_name,
+            sw_version=str(year) if year else None,
+        )
+
+    def _location_data(self) -> dict | None:
+        """Return location dict from coordinator data, or None."""
+        data = self.coordinator.data
+        if not data:
+            return None
+        return data.get("location", {}).get(self._vin)
+
+    @property
+    def latitude(self) -> float | None:
+        """Return latitude."""
+        loc = self._location_data()
+        if loc is None:
+            return None
+        return loc.get("latitude")
+
+    @property
+    def longitude(self) -> float | None:
+        """Return longitude."""
+        loc = self._location_data()
+        if loc is None:
+            return None
+        return loc.get("longitude")
+
+    @property
+    def extra_state_attributes(self) -> dict | None:
+        """Return extra state attributes."""
+        loc = self._location_data()
+        if loc is None:
+            return None
+        timestamp_ms = loc.get("timestamp_ms")
+        if timestamp_ms is None:
+            return None
+        return {
+            "location_timestamp": datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC).isoformat(),
+        }

--- a/custom_components/polestar_soc/strings.json
+++ b/custom_components/polestar_soc/strings.json
@@ -84,6 +84,11 @@
       "charging_end_time": {
         "name": "Charging end time"
       }
+    },
+    "device_tracker": {
+      "location": {
+        "name": "Location"
+      }
     }
   }
 }

--- a/custom_components/polestar_soc/translations/en.json
+++ b/custom_components/polestar_soc/translations/en.json
@@ -84,6 +84,11 @@
       "charging_end_time": {
         "name": "Charging end time"
       }
+    },
+    "device_tracker": {
+      "location": {
+        "name": "Location"
+      }
     }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,8 +74,23 @@ VIN = "YSMYKEAE1RB000001"
 
 
 @pytest.fixture
+def sample_location():
+    """Return a sample location dict (as returned by CepClient)."""
+    return {
+        "latitude": 59.329323,
+        "longitude": 18.068581,
+        "timestamp_ms": 1772990058845,
+    }
+
+
+@pytest.fixture
 def sample_coordinator_data(
-    sample_vehicle, sample_battery, sample_odometer, sample_climate, sample_cep_battery
+    sample_vehicle,
+    sample_battery,
+    sample_odometer,
+    sample_climate,
+    sample_cep_battery,
+    sample_location,
 ):
     """Return a full coordinator data dict combining all sources."""
     vin = sample_vehicle["vin"]
@@ -87,4 +102,5 @@ def sample_coordinator_data(
         "charge_timer": {},
         "climate": {vin: sample_climate},
         "cep_battery": {vin: sample_cep_battery},
+        "location": {vin: sample_location},
     }

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -5,15 +5,18 @@ import struct
 import pytest
 
 from custom_components.polestar_soc.cep import (
+    _build_location_request,
     _build_vin_request,
     _format_climate_status,
     _format_heating_intensity,
     _parse_battery_response,
     _parse_climate_response,
+    _parse_location_response,
 )
 from custom_components.polestar_soc.proto import (
     _decode_message,
     _encode_field_bytes,
+    _encode_field_varint,
     _get_submessage,
 )
 
@@ -160,3 +163,67 @@ class TestFormatHeatingIntensity:
     def test_unknown_value(self):
         result = _format_heating_intensity(42)
         assert result == "Unknown (42)"
+
+
+def _build_location_payload(
+    vin: str, longitude: float, latitude: float, timestamp_ms: int
+) -> bytes:
+    """Build a synthetic GetLastKnownLocation response payload."""
+    # field 1 = VIN (string), field 2 = longitude (double/fixed64),
+    # field 3 = latitude (double/fixed64), field 4 = timestamp_ms (varint)
+    data = _encode_field_bytes(1, vin.encode("utf-8"))
+    # Wire type 1 (fixed64) for doubles: tag = (field_number << 3) | 1
+    data += struct.pack("<B", (2 << 3) | 1) + struct.pack("<d", longitude)
+    data += struct.pack("<B", (3 << 3) | 1) + struct.pack("<d", latitude)
+    data += _encode_field_varint(4, timestamp_ms)
+    return data
+
+
+LOCATION_PAYLOAD = _build_location_payload(
+    TEST_VIN, longitude=18.068581, latitude=59.329323, timestamp_ms=1772990058845
+)
+
+
+class TestBuildLocationRequest:
+    def test_produces_field_1_string(self):
+        result = _build_location_request(TEST_VIN)
+        fields = _decode_message(result)
+        assert 1 in fields
+        assert fields[1][0] == TEST_VIN.encode("utf-8")
+        assert 2 not in fields
+
+    def test_roundtrip_vin(self):
+        result = _build_location_request(TEST_VIN)
+        expected = _encode_field_bytes(1, TEST_VIN.encode("utf-8"))
+        assert result == expected
+
+
+class TestParseLocationResponse:
+    def test_parsed_response(self):
+        result = _parse_location_response(LOCATION_PAYLOAD)
+        assert result["latitude"] == pytest.approx(59.329323)
+        assert result["longitude"] == pytest.approx(18.068581)
+        assert result["timestamp_ms"] == 1772990058845
+
+    def test_empty_response(self):
+        result = _parse_location_response(b"")
+        assert result["latitude"] is None
+        assert result["longitude"] is None
+        assert result["timestamp_ms"] is None
+
+    def test_missing_coordinates(self):
+        """Response with only VIN returns None values."""
+        data = _encode_field_bytes(1, TEST_VIN.encode("utf-8"))
+        result = _parse_location_response(data)
+        assert result["latitude"] is None
+        assert result["longitude"] is None
+        assert result["timestamp_ms"] is None
+
+    def test_top_level_decode(self):
+        """Verify location fields are at top level (no envelope nesting)."""
+        fields = _decode_message(LOCATION_PAYLOAD)
+        assert fields[1][0] == TEST_VIN.encode("utf-8")
+        # Fields 2 and 3 are fixed64 (doubles stored as uint64)
+        assert 2 in fields
+        assert 3 in fields
+        assert 4 in fields

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1,0 +1,74 @@
+"""Tests for device_tracker platform — vehicle GPS location."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.device_tracker import SourceType
+
+from custom_components.polestar_soc.const import DOMAIN
+from custom_components.polestar_soc.device_tracker import PolestarDeviceTracker
+
+VIN = "YSMYKEAE1RB000001"
+
+
+def _make_tracker(coordinator_data: dict, vehicle: dict, vin: str) -> PolestarDeviceTracker:
+    """Create a PolestarDeviceTracker with a mock coordinator."""
+    coordinator = MagicMock()
+    coordinator.data = coordinator_data
+    return PolestarDeviceTracker(coordinator, vehicle, vin)
+
+
+class TestPolestarDeviceTracker:
+    def test_latitude(self, sample_coordinator_data, sample_vehicle):
+        tracker = _make_tracker(sample_coordinator_data, sample_vehicle, VIN)
+        assert tracker.latitude == 59.329323
+
+    def test_longitude(self, sample_coordinator_data, sample_vehicle):
+        tracker = _make_tracker(sample_coordinator_data, sample_vehicle, VIN)
+        assert tracker.longitude == 18.068581
+
+    def test_source_type(self, sample_coordinator_data, sample_vehicle):
+        tracker = _make_tracker(sample_coordinator_data, sample_vehicle, VIN)
+        assert tracker.source_type == SourceType.GPS
+
+    def test_unique_id(self, sample_coordinator_data, sample_vehicle):
+        tracker = _make_tracker(sample_coordinator_data, sample_vehicle, VIN)
+        assert tracker.unique_id == f"{VIN}_location"
+
+    def test_device_info(self, sample_coordinator_data, sample_vehicle):
+        tracker = _make_tracker(sample_coordinator_data, sample_vehicle, VIN)
+        assert tracker.device_info["identifiers"] == {(DOMAIN, VIN)}
+        assert tracker.device_info["manufacturer"] == "Polestar"
+
+    def test_extra_state_attributes(self, sample_coordinator_data, sample_vehicle):
+        tracker = _make_tracker(sample_coordinator_data, sample_vehicle, VIN)
+        attrs = tracker.extra_state_attributes
+        assert attrs is not None
+        assert "location_timestamp" in attrs
+        assert attrs["location_timestamp"] == "2026-03-08T17:14:18.845000+00:00"
+
+    def test_none_when_no_location_data(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["location"] = {}
+        tracker = _make_tracker(sample_coordinator_data, sample_vehicle, VIN)
+        assert tracker.latitude is None
+        assert tracker.longitude is None
+        assert tracker.extra_state_attributes is None
+
+    def test_none_when_no_coordinator_data(self, sample_vehicle):
+        coordinator_data = None
+        coordinator = MagicMock()
+        coordinator.data = coordinator_data
+        tracker = PolestarDeviceTracker(coordinator, sample_vehicle, VIN)
+        assert tracker.latitude is None
+        assert tracker.longitude is None
+        assert tracker.extra_state_attributes is None
+
+    def test_none_when_location_values_none(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["location"][VIN] = {
+            "latitude": None,
+            "longitude": None,
+            "timestamp_ms": None,
+        }
+        tracker = _make_tracker(sample_coordinator_data, sample_vehicle, VIN)
+        assert tracker.latitude is None
+        assert tracker.longitude is None
+        assert tracker.extra_state_attributes is None


### PR DESCRIPTION
## Summary

- Add `device_tracker` entity that shows the vehicle's GPS location on the HA map
- Fetch location from `DtlInternetService/GetLastKnownLocation` on the Volvo CEP gRPC API
- Works with the existing web client token — no 2FA required
- One tracker entity per vehicle, attached to the same HA device as other entities
- Exposes `location_timestamp` as an extra state attribute (UTC ISO datetime)
- HA automatically determines state (`home`/`not_home`/zone) based on proximity

## Changes

- **`cep.py`** — Add `get_location()` method with request builder (VIN in field 1) and response parser (top-level lat/lon/timestamp)
- **`coordinator.py`** — Fetch location per VIN in `_do_fetch()` alongside climate/battery
- **`device_tracker.py`** — New `PolestarDeviceTracker(CoordinatorEntity, TrackerEntity)` entity
- **`__init__.py`** — Register `Platform.DEVICE_TRACKER`
- **`strings.json` / `en.json`** — Add entity translation
- **Tests** — 15 new tests covering request builder, response parser, and entity properties

## Test plan

- [x] All 131 tests pass
- [x] Verified live against real vehicle — coordinates match expected location
- [ ] Verify entity appears on HA map with correct pin
- [ ] Verify `home`/`not_home` state based on zone proximity
- [ ] Verify graceful degradation when location API is unavailable