### PR TITLE
Add exterior state binary sensors via CEP gRPC API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,33 @@ Custom Home Assistant integration for Polestar vehicles. Provides battery, charg
 | Rear Right Seat Heating | — | Off / Low / Medium / High |
 | Steering Wheel Heating | — | Off / Low / Medium / High |
 
+### Device Tracker
+
+| Entity | Description |
+|--------|-------------|
+| Location | Vehicle GPS position with timestamp |
+
+### Binary Sensors
+
+| Sensor | Device Class | Description |
+|--------|-------------|-------------|
+| Central Lock | Lock | Locked / Unlocked |
+| Front Left Door | Door | Open / Closed / Ajar |
+| Front Right Door | Door | Open / Closed / Ajar |
+| Rear Left Door | Door | Open / Closed / Ajar |
+| Rear Right Door | Door | Open / Closed / Ajar |
+| Front Left Window* | Window | Open / Closed |
+| Front Right Window* | Window | Open / Closed |
+| Rear Left Window* | Window | Open / Closed |
+| Rear Right Window* | Window | Open / Closed |
+| Hood* | Opening | Open / Closed |
+| Tailgate* | Opening | Open / Closed |
+| Tank Lid* | Opening | Open / Closed |
+| Sunroof* | Opening | Open / Closed |
+| Alarm* | Safety | Idle / Triggered |
+
+*Disabled by default — enable in the entity registry.
+
 ### Controls
 
 | Entity | Type | Description |

--- a/custom_components/polestar_soc/__init__.py
+++ b/custom_components/polestar_soc/__init__.py
@@ -14,6 +14,7 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.TIME,
     Platform.DEVICE_TRACKER,
+    Platform.BINARY_SENSOR,
 ]
 
 

--- a/custom_components/polestar_soc/binary_sensor.py
+++ b/custom_components/polestar_soc/binary_sensor.py
@@ -1,0 +1,259 @@
+"""Binary sensor platform for Polestar — vehicle exterior state."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import ALARM_STATUS_MAP, DOMAIN, LOCK_STATUS_MAP, OPEN_STATUS_MAP
+from .coordinator import PolestarCoordinator
+
+
+@dataclass(frozen=True, kw_only=True)
+class PolestarBinarySensorDescription(BinarySensorEntityDescription):
+    """Describe a Polestar binary sensor."""
+
+    is_on_fn: Callable[[dict, str], bool | None]
+
+
+# ---------------------------------------------------------------------------
+# is_on helpers
+# ---------------------------------------------------------------------------
+
+
+def _lock_is_on(data: dict, vin: str) -> bool | None:
+    """Central lock: True=Unlocked, False=Locked, None=Unknown."""
+    exterior = data.get("exterior", {}).get(vin)
+    if exterior is None:
+        return None
+    val = exterior.get("central_lock")
+    if val is None or val == 0:
+        return None
+    return val != 2  # anything other than LOCKED(2) is "on"
+
+
+def _open_status_is_on(key: str) -> Callable[[dict, str], bool | None]:
+    """Create an is_on_fn for an OpenStatus field (doors, windows, openings)."""
+
+    def _fn(data: dict, vin: str) -> bool | None:
+        exterior = data.get("exterior", {}).get(vin)
+        if exterior is None:
+            return None
+        val = exterior.get(key)
+        if val is None or val == 0:
+            return None
+        return val in (1, 3)  # OPEN(1) or AJAR(3)
+
+    return _fn
+
+
+def _alarm_is_on(data: dict, vin: str) -> bool | None:
+    """Alarm: True=Triggered, False=Idle, None=Unknown."""
+    exterior = data.get("exterior", {}).get(vin)
+    if exterior is None:
+        return None
+    val = exterior.get("alarm")
+    if val is None or val == 0:
+        return None
+    return val == 2  # TRIGGERED(2)
+
+
+# ---------------------------------------------------------------------------
+# Entity descriptions
+# ---------------------------------------------------------------------------
+
+BINARY_SENSOR_DESCRIPTIONS: tuple[PolestarBinarySensorDescription, ...] = (
+    PolestarBinarySensorDescription(
+        key="central_lock",
+        translation_key="central_lock",
+        device_class=BinarySensorDeviceClass.LOCK,
+        is_on_fn=_lock_is_on,
+    ),
+    PolestarBinarySensorDescription(
+        key="front_left_door",
+        translation_key="front_left_door",
+        device_class=BinarySensorDeviceClass.DOOR,
+        is_on_fn=_open_status_is_on("front_left_door"),
+    ),
+    PolestarBinarySensorDescription(
+        key="front_right_door",
+        translation_key="front_right_door",
+        device_class=BinarySensorDeviceClass.DOOR,
+        is_on_fn=_open_status_is_on("front_right_door"),
+    ),
+    PolestarBinarySensorDescription(
+        key="rear_left_door",
+        translation_key="rear_left_door",
+        device_class=BinarySensorDeviceClass.DOOR,
+        is_on_fn=_open_status_is_on("rear_left_door"),
+    ),
+    PolestarBinarySensorDescription(
+        key="rear_right_door",
+        translation_key="rear_right_door",
+        device_class=BinarySensorDeviceClass.DOOR,
+        is_on_fn=_open_status_is_on("rear_right_door"),
+    ),
+    # --- Disabled by default ---
+    PolestarBinarySensorDescription(
+        key="front_left_window",
+        translation_key="front_left_window",
+        device_class=BinarySensorDeviceClass.WINDOW,
+        entity_registry_enabled_default=False,
+        is_on_fn=_open_status_is_on("front_left_window"),
+    ),
+    PolestarBinarySensorDescription(
+        key="front_right_window",
+        translation_key="front_right_window",
+        device_class=BinarySensorDeviceClass.WINDOW,
+        entity_registry_enabled_default=False,
+        is_on_fn=_open_status_is_on("front_right_window"),
+    ),
+    PolestarBinarySensorDescription(
+        key="rear_left_window",
+        translation_key="rear_left_window",
+        device_class=BinarySensorDeviceClass.WINDOW,
+        entity_registry_enabled_default=False,
+        is_on_fn=_open_status_is_on("rear_left_window"),
+    ),
+    PolestarBinarySensorDescription(
+        key="rear_right_window",
+        translation_key="rear_right_window",
+        device_class=BinarySensorDeviceClass.WINDOW,
+        entity_registry_enabled_default=False,
+        is_on_fn=_open_status_is_on("rear_right_window"),
+    ),
+    PolestarBinarySensorDescription(
+        key="hood",
+        translation_key="hood",
+        device_class=BinarySensorDeviceClass.OPENING,
+        entity_registry_enabled_default=False,
+        is_on_fn=_open_status_is_on("hood"),
+    ),
+    PolestarBinarySensorDescription(
+        key="tailgate",
+        translation_key="tailgate",
+        device_class=BinarySensorDeviceClass.OPENING,
+        entity_registry_enabled_default=False,
+        is_on_fn=_open_status_is_on("tailgate"),
+    ),
+    PolestarBinarySensorDescription(
+        key="tank_lid",
+        translation_key="tank_lid",
+        device_class=BinarySensorDeviceClass.OPENING,
+        entity_registry_enabled_default=False,
+        is_on_fn=_open_status_is_on("tank_lid"),
+    ),
+    PolestarBinarySensorDescription(
+        key="sunroof",
+        translation_key="sunroof",
+        device_class=BinarySensorDeviceClass.OPENING,
+        entity_registry_enabled_default=False,
+        is_on_fn=_open_status_is_on("sunroof"),
+    ),
+    PolestarBinarySensorDescription(
+        key="alarm",
+        translation_key="alarm",
+        device_class=BinarySensorDeviceClass.SAFETY,
+        entity_registry_enabled_default=False,
+        is_on_fn=_alarm_is_on,
+    ),
+)
+
+# Mapping from description key to the appropriate status map for raw_state labels
+_STATUS_MAP_BY_KEY: dict[str, dict[int, str | None]] = {
+    "central_lock": LOCK_STATUS_MAP,
+    "alarm": ALARM_STATUS_MAP,
+}
+
+
+def _get_status_map(key: str) -> dict[int, str | None]:
+    return _STATUS_MAP_BY_KEY.get(key, OPEN_STATUS_MAP)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Polestar binary sensors from a config entry."""
+    coordinator: PolestarCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities: list[PolestarBinarySensor] = []
+    for vehicle in coordinator.data.get("vehicles", []):
+        vin = vehicle["vin"]
+        for description in BINARY_SENSOR_DESCRIPTIONS:
+            entities.append(PolestarBinarySensor(coordinator, description, vehicle, vin))
+
+    async_add_entities(entities)
+
+
+class PolestarBinarySensor(CoordinatorEntity[PolestarCoordinator], BinarySensorEntity):
+    """Representation of a Polestar binary sensor."""
+
+    entity_description: PolestarBinarySensorDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: PolestarCoordinator,
+        description: PolestarBinarySensorDescription,
+        vehicle: dict,
+        vin: str,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._vin = vin
+        self._attr_unique_id = f"{vin}_{description.key}"
+
+        model_name = "Polestar"
+        content = vehicle.get("content")
+        if content and content.get("model"):
+            model_name = content["model"].get("name", model_name)
+        year = vehicle.get("modelYear", "")
+        device_name = f"{model_name} ({year})" if year else model_name
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vin)},
+            name=device_name,
+            manufacturer="Polestar",
+            model=model_name,
+            sw_version=str(year) if year else None,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the binary sensor is on."""
+        data = self.coordinator.data
+        if not data:
+            return None
+        return self.entity_description.is_on_fn(data, self._vin)
+
+    @property
+    def extra_state_attributes(self) -> dict | None:
+        """Return extra state attributes including raw enum label."""
+        data = self.coordinator.data
+        if not data:
+            return None
+        exterior = data.get("exterior", {}).get(self._vin)
+        if exterior is None:
+            return None
+        raw_val = exterior.get(self.entity_description.key)
+        if raw_val is None:
+            return None
+        status_map = _get_status_map(self.entity_description.key)
+        label = status_map.get(raw_val, f"Unknown ({raw_val})")
+        if label is None:
+            return None
+        return {"raw_state": label}

--- a/custom_components/polestar_soc/cep.py
+++ b/custom_components/polestar_soc/cep.py
@@ -35,6 +35,9 @@ _METHOD_GET_CLIMATE = (
     ".ParkingClimatizationService/GetLatestParkingClimatization"
 )
 _METHOD_GET_BATTERY = "/services.vehiclestates.battery.BatteryService/GetLatestBattery"
+_METHOD_GET_EXTERIOR = (
+    "/services.vehiclestates.exterior.ExteriorService/GetLatestExterior"
+)
 _METHOD_GET_LOCATION = "/dtlinternet.DtlInternetService/GetLastKnownLocation"
 
 # BatteryState field numbers captured in raw_fields for debugging.
@@ -166,6 +169,47 @@ def _parse_battery_response(data: bytes) -> dict:
     }
 
 
+# ExteriorState field numbers → dict keys
+_EXTERIOR_FIELDS: tuple[tuple[int, str], ...] = (
+    (2, "central_lock"),
+    (3, "front_left_door"),
+    (4, "front_right_door"),
+    (5, "rear_left_door"),
+    (6, "rear_right_door"),
+    (7, "front_left_window"),
+    (8, "front_right_window"),
+    (9, "rear_left_window"),
+    (10, "rear_right_window"),
+    (11, "hood"),
+    (12, "tailgate"),
+    (13, "tank_lid"),
+    (14, "sunroof"),
+    (15, "alarm"),
+)
+
+
+def _parse_exterior_response(data: bytes) -> dict:
+    """Parse GetLatestExterior response.
+
+    Two-level decode: outer envelope has field 3 = ExteriorState sub-message.
+    Returns raw integer enum values (0-3) for each field, or None if missing.
+    """
+    empty: dict = {key: None for _, key in _EXTERIOR_FIELDS}
+    if not data:
+        return empty
+
+    outer = _decode_message(data)
+    state = _get_submessage(outer, 3)
+    if state is None:
+        return empty
+
+    result: dict = {}
+    for field_num, key in _EXTERIOR_FIELDS:
+        val = _get_int(state, field_num)
+        result[key] = val if val else None
+    return result
+
+
 def _parse_location_response(data: bytes) -> dict:
     """Parse GetLastKnownLocation response.
 
@@ -258,6 +302,21 @@ class CepClient:
             return _parse_battery_response(response)
         except grpc.RpcError as err:
             _LOGGER.warning("CEP GetLatestBattery failed: %s", err)
+            raise
+
+    def get_exterior(self, vin: str) -> dict:
+        """Get current exterior state (lock, doors, windows, etc.)."""
+        channel = self._get_channel()
+        method = channel.unary_unary(
+            _METHOD_GET_EXTERIOR,
+            request_serializer=_identity_serialize,
+            response_deserializer=_identity_deserialize,
+        )
+        try:
+            response = method(_build_vin_request(vin), metadata=self._metadata(vin), timeout=30)
+            return _parse_exterior_response(response)
+        except grpc.RpcError as err:
+            _LOGGER.warning("CEP GetLatestExterior failed: %s", err)
             raise
 
     def get_location(self, vin: str) -> dict:

--- a/custom_components/polestar_soc/cep.py
+++ b/custom_components/polestar_soc/cep.py
@@ -35,9 +35,7 @@ _METHOD_GET_CLIMATE = (
     ".ParkingClimatizationService/GetLatestParkingClimatization"
 )
 _METHOD_GET_BATTERY = "/services.vehiclestates.battery.BatteryService/GetLatestBattery"
-_METHOD_GET_EXTERIOR = (
-    "/services.vehiclestates.exterior.ExteriorService/GetLatestExterior"
-)
+_METHOD_GET_EXTERIOR = "/services.vehiclestates.exterior.ExteriorService/GetLatestExterior"
 _METHOD_GET_LOCATION = "/dtlinternet.DtlInternetService/GetLastKnownLocation"
 
 # BatteryState field numbers captured in raw_fields for debugging.

--- a/custom_components/polestar_soc/const.py
+++ b/custom_components/polestar_soc/const.py
@@ -90,3 +90,23 @@ HEATING_INTENSITY_MAP: dict[int, str] = {
     2: "Medium",
     3: "High",
 }
+
+# Exterior state enums (ExteriorService)
+LOCK_STATUS_MAP: dict[int, str | None] = {
+    0: None,
+    1: "Unlocked",
+    2: "Locked",
+}
+
+OPEN_STATUS_MAP: dict[int, str | None] = {
+    0: None,
+    1: "Open",
+    2: "Closed",
+    3: "Ajar",
+}
+
+ALARM_STATUS_MAP: dict[int, str | None] = {
+    0: None,
+    1: "Idle",
+    2: "Triggered",
+}

--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -516,6 +516,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
                     "climate": {},
                     "cep_battery": {},
                     "location": {},
+                    "exterior": {},
                 }
 
             vins = [v["vin"] for v in vehicles]
@@ -548,6 +549,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
             climate_by_vin: dict = {}
             cep_battery_by_vin: dict = {}
             location_by_vin: dict = {}
+            exterior_by_vin: dict = {}
             for vin in vins:
                 try:
                     climate_by_vin[vin] = self.cep.get_parking_climatization(vin)
@@ -561,6 +563,10 @@ class PolestarCoordinator(DataUpdateCoordinator):
                     location_by_vin[vin] = self.cep.get_location(vin)
                 except Exception:
                     _LOGGER.debug("Failed to fetch CEP location for %s", vin)
+                try:
+                    exterior_by_vin[vin] = self.cep.get_exterior(vin)
+                except Exception:
+                    _LOGGER.debug("Failed to fetch CEP exterior for %s", vin)
 
             return {
                 "vehicles": vehicles,
@@ -571,6 +577,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 "climate": climate_by_vin,
                 "cep_battery": cep_battery_by_vin,
                 "location": location_by_vin,
+                "exterior": exterior_by_vin,
             }
 
         return await self.hass.async_add_executor_job(_do_fetch)

--- a/custom_components/polestar_soc/strings.json
+++ b/custom_components/polestar_soc/strings.json
@@ -89,6 +89,50 @@
       "location": {
         "name": "Location"
       }
+    },
+    "binary_sensor": {
+      "central_lock": {
+        "name": "Central lock"
+      },
+      "front_left_door": {
+        "name": "Front left door"
+      },
+      "front_right_door": {
+        "name": "Front right door"
+      },
+      "rear_left_door": {
+        "name": "Rear left door"
+      },
+      "rear_right_door": {
+        "name": "Rear right door"
+      },
+      "front_left_window": {
+        "name": "Front left window"
+      },
+      "front_right_window": {
+        "name": "Front right window"
+      },
+      "rear_left_window": {
+        "name": "Rear left window"
+      },
+      "rear_right_window": {
+        "name": "Rear right window"
+      },
+      "hood": {
+        "name": "Hood"
+      },
+      "tailgate": {
+        "name": "Tailgate"
+      },
+      "tank_lid": {
+        "name": "Tank lid"
+      },
+      "sunroof": {
+        "name": "Sunroof"
+      },
+      "alarm": {
+        "name": "Alarm"
+      }
     }
   }
 }

--- a/custom_components/polestar_soc/translations/en.json
+++ b/custom_components/polestar_soc/translations/en.json
@@ -89,6 +89,50 @@
       "location": {
         "name": "Location"
       }
+    },
+    "binary_sensor": {
+      "central_lock": {
+        "name": "Central lock"
+      },
+      "front_left_door": {
+        "name": "Front left door"
+      },
+      "front_right_door": {
+        "name": "Front right door"
+      },
+      "rear_left_door": {
+        "name": "Rear left door"
+      },
+      "rear_right_door": {
+        "name": "Rear right door"
+      },
+      "front_left_window": {
+        "name": "Front left window"
+      },
+      "front_right_window": {
+        "name": "Front right window"
+      },
+      "rear_left_window": {
+        "name": "Rear left window"
+      },
+      "rear_right_window": {
+        "name": "Rear right window"
+      },
+      "hood": {
+        "name": "Hood"
+      },
+      "tailgate": {
+        "name": "Tailgate"
+      },
+      "tank_lid": {
+        "name": "Tank lid"
+      },
+      "sunroof": {
+        "name": "Sunroof"
+      },
+      "alarm": {
+        "name": "Alarm"
+      }
     }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,27 @@ def sample_cep_battery():
     }
 
 
+@pytest.fixture
+def sample_exterior():
+    """Return a sample exterior state dict (as returned by CepClient)."""
+    return {
+        "central_lock": 2,  # LOCKED
+        "front_left_door": 2,  # CLOSED
+        "front_right_door": 2,  # CLOSED
+        "rear_left_door": 2,  # CLOSED
+        "rear_right_door": 2,  # CLOSED
+        "front_left_window": 2,  # CLOSED
+        "front_right_window": 2,  # CLOSED
+        "rear_left_window": 2,  # CLOSED
+        "rear_right_window": 2,  # CLOSED
+        "hood": 2,  # CLOSED
+        "tailgate": 2,  # CLOSED
+        "tank_lid": 2,  # CLOSED
+        "sunroof": 0,  # UNSPECIFIED (no sunroof)
+        "alarm": 1,  # IDLE
+    }
+
+
 VIN = "YSMYKEAE1RB000001"
 
 
@@ -91,6 +112,7 @@ def sample_coordinator_data(
     sample_climate,
     sample_cep_battery,
     sample_location,
+    sample_exterior,
 ):
     """Return a full coordinator data dict combining all sources."""
     vin = sample_vehicle["vin"]
@@ -103,4 +125,5 @@ def sample_coordinator_data(
         "climate": {vin: sample_climate},
         "cep_battery": {vin: sample_cep_battery},
         "location": {vin: sample_location},
+        "exterior": {vin: sample_exterior},
     }

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,176 @@
+"""Tests for binary_sensor platform — vehicle exterior state."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+from custom_components.polestar_soc.binary_sensor import (
+    BINARY_SENSOR_DESCRIPTIONS,
+    PolestarBinarySensor,
+)
+from custom_components.polestar_soc.const import DOMAIN
+
+VIN = "YSMYKEAE1RB000001"
+
+
+def _make_sensor(
+    coordinator_data: dict | None,
+    vehicle: dict,
+    vin: str,
+    key: str = "central_lock",
+) -> PolestarBinarySensor:
+    """Create a PolestarBinarySensor with a mock coordinator."""
+    coordinator = MagicMock()
+    coordinator.data = coordinator_data
+    desc = next(d for d in BINARY_SENSOR_DESCRIPTIONS if d.key == key)
+    return PolestarBinarySensor(coordinator, desc, vehicle, vin)
+
+
+class TestLockIsOn:
+    def test_locked(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["central_lock"] = 2  # LOCKED
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
+        assert sensor.is_on is False
+
+    def test_unlocked(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["central_lock"] = 1  # UNLOCKED
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
+        assert sensor.is_on is True
+
+    def test_unspecified(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["central_lock"] = 0  # UNSPECIFIED
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
+        assert sensor.is_on is None
+
+
+class TestDoorIsOn:
+    def test_closed(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "front_left_door")
+        assert sensor.is_on is False  # fixture has CLOSED(2)
+
+    def test_open(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["front_left_door"] = 1  # OPEN
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "front_left_door")
+        assert sensor.is_on is True
+
+    def test_ajar(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["front_left_door"] = 3  # AJAR
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "front_left_door")
+        assert sensor.is_on is True
+
+    def test_unspecified(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["front_left_door"] = 0  # UNSPECIFIED
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "front_left_door")
+        assert sensor.is_on is None
+
+
+class TestAlarmIsOn:
+    def test_idle(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "alarm")
+        assert sensor.is_on is False  # fixture has IDLE(1)
+
+    def test_triggered(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["alarm"] = 2  # TRIGGERED
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "alarm")
+        assert sensor.is_on is True
+
+    def test_unspecified(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["alarm"] = 0  # UNSPECIFIED
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "alarm")
+        assert sensor.is_on is None
+
+
+class TestBinarySensorEntity:
+    def test_unique_id(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
+        assert sensor.unique_id == f"{VIN}_central_lock"
+
+    def test_device_info(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
+        assert sensor.device_info["identifiers"] == {(DOMAIN, VIN)}
+        assert sensor.device_info["manufacturer"] == "Polestar"
+
+    def test_device_class_lock(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
+        assert sensor.device_class == BinarySensorDeviceClass.LOCK
+
+    def test_device_class_door(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "front_left_door")
+        assert sensor.device_class == BinarySensorDeviceClass.DOOR
+
+    def test_device_class_window(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "front_left_window")
+        assert sensor.device_class == BinarySensorDeviceClass.WINDOW
+
+    def test_device_class_opening(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "hood")
+        assert sensor.device_class == BinarySensorDeviceClass.OPENING
+
+    def test_device_class_safety(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "alarm")
+        assert sensor.device_class == BinarySensorDeviceClass.SAFETY
+
+
+class TestExtraStateAttributes:
+    def test_locked_label(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
+        attrs = sensor.extra_state_attributes
+        assert attrs is not None
+        assert attrs["raw_state"] == "Locked"
+
+    def test_unlocked_label(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["central_lock"] = 1
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
+        assert sensor.extra_state_attributes["raw_state"] == "Unlocked"
+
+    def test_door_closed_label(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "front_left_door")
+        assert sensor.extra_state_attributes["raw_state"] == "Closed"
+
+    def test_door_ajar_label(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["front_left_door"] = 3
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "front_left_door")
+        assert sensor.extra_state_attributes["raw_state"] == "Ajar"
+
+    def test_alarm_idle_label(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "alarm")
+        assert sensor.extra_state_attributes["raw_state"] == "Idle"
+
+    def test_unspecified_returns_none(self, sample_coordinator_data, sample_vehicle):
+        """UNSPECIFIED(0) exterior value → extra_state_attributes is None."""
+        sample_coordinator_data["exterior"][VIN]["sunroof"] = 0
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "sunroof")
+        # sunroof is 0 in fixture, raw_val is 0 which is falsy → returns None
+        assert sensor.extra_state_attributes is None
+
+
+class TestNoneHandling:
+    def test_none_when_no_coordinator_data(self, sample_vehicle):
+        sensor = _make_sensor(None, sample_vehicle, VIN, "central_lock")
+        assert sensor.is_on is None
+        assert sensor.extra_state_attributes is None
+
+    def test_none_when_no_exterior_data(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"] = {}
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
+        assert sensor.is_on is None
+        assert sensor.extra_state_attributes is None
+
+    def test_none_when_field_is_none(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["central_lock"] = None
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
+        assert sensor.is_on is None
+        assert sensor.extra_state_attributes is None
+
+
+class TestDescriptionCounts:
+    def test_total_descriptions(self):
+        assert len(BINARY_SENSOR_DESCRIPTIONS) == 14
+
+    def test_enabled_by_default_count(self):
+        enabled = [d for d in BINARY_SENSOR_DESCRIPTIONS if d.entity_registry_enabled_default]
+        assert len(enabled) == 5  # central_lock + 4 doors
+
+    def test_disabled_by_default_count(self):
+        disabled = [d for d in BINARY_SENSOR_DESCRIPTIONS if not d.entity_registry_enabled_default]
+        assert len(disabled) == 9  # 4 windows + hood + tailgate + tank_lid + sunroof + alarm

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -11,6 +11,7 @@ from custom_components.polestar_soc.cep import (
     _format_heating_intensity,
     _parse_battery_response,
     _parse_climate_response,
+    _parse_exterior_response,
     _parse_location_response,
 )
 from custom_components.polestar_soc.proto import (
@@ -227,3 +228,117 @@ class TestParseLocationResponse:
         assert 2 in fields
         assert 3 in fields
         assert 4 in fields
+
+
+def _build_exterior_state(field_values: dict[int, int]) -> bytes:
+    """Build an ExteriorState sub-message from {field_number: varint_value}."""
+    data = b""
+    for field_num in sorted(field_values):
+        data += _encode_field_varint(field_num, field_values[field_num])
+    return data
+
+
+def _build_exterior_payload(vin: str, field_values: dict[int, int]) -> bytes:
+    """Build a synthetic GetLatestExterior response with two-level envelope."""
+    state_bytes = _build_exterior_state(field_values)
+    # Outer envelope: field 2 = VIN, field 3 = ExteriorState sub-message
+    data = _encode_field_bytes(2, vin.encode("utf-8"))
+    data += _encode_field_bytes(3, state_bytes)
+    return data
+
+
+# All locked/closed, alarm idle
+EXTERIOR_ALL_LOCKED = _build_exterior_payload(
+    TEST_VIN,
+    {
+        2: 2,   # central_lock: LOCKED
+        3: 2,   # front_left_door: CLOSED
+        4: 2,   # front_right_door: CLOSED
+        5: 2,   # rear_left_door: CLOSED
+        6: 2,   # rear_right_door: CLOSED
+        7: 2,   # front_left_window: CLOSED
+        8: 2,   # front_right_window: CLOSED
+        9: 2,   # rear_left_window: CLOSED
+        10: 2,  # rear_right_window: CLOSED
+        11: 2,  # hood: CLOSED
+        12: 2,  # tailgate: CLOSED
+        13: 2,  # tank_lid: CLOSED
+        15: 1,  # alarm: IDLE
+    },
+)
+
+# Mixed state: unlocked, some doors open/ajar, alarm triggered
+EXTERIOR_MIXED = _build_exterior_payload(
+    TEST_VIN,
+    {
+        2: 1,   # central_lock: UNLOCKED
+        3: 1,   # front_left_door: OPEN
+        4: 3,   # front_right_door: AJAR
+        5: 2,   # rear_left_door: CLOSED
+        6: 2,   # rear_right_door: CLOSED
+        7: 1,   # front_left_window: OPEN
+        8: 2,   # front_right_window: CLOSED
+        9: 2,   # rear_left_window: CLOSED
+        10: 2,  # rear_right_window: CLOSED
+        11: 2,  # hood: CLOSED
+        12: 1,  # tailgate: OPEN
+        13: 2,  # tank_lid: CLOSED
+        14: 0,  # sunroof: UNSPECIFIED
+        15: 2,  # alarm: TRIGGERED
+    },
+)
+
+
+class TestParseExteriorResponse:
+    def test_all_locked_closed(self):
+        result = _parse_exterior_response(EXTERIOR_ALL_LOCKED)
+        assert result["central_lock"] == 2  # LOCKED
+        assert result["front_left_door"] == 2  # CLOSED
+        assert result["front_right_door"] == 2  # CLOSED
+        assert result["rear_left_door"] == 2  # CLOSED
+        assert result["rear_right_door"] == 2  # CLOSED
+        assert result["front_left_window"] == 2  # CLOSED
+        assert result["front_right_window"] == 2  # CLOSED
+        assert result["rear_left_window"] == 2  # CLOSED
+        assert result["rear_right_window"] == 2  # CLOSED
+        assert result["hood"] == 2  # CLOSED
+        assert result["tailgate"] == 2  # CLOSED
+        assert result["tank_lid"] == 2  # CLOSED
+        assert result["sunroof"] is None  # not in payload → UNSPECIFIED → None
+        assert result["alarm"] == 1  # IDLE
+
+    def test_mixed_open_ajar(self):
+        result = _parse_exterior_response(EXTERIOR_MIXED)
+        assert result["central_lock"] == 1  # UNLOCKED
+        assert result["front_left_door"] == 1  # OPEN
+        assert result["front_right_door"] == 3  # AJAR
+        assert result["rear_left_door"] == 2  # CLOSED
+        assert result["front_left_window"] == 1  # OPEN
+        assert result["front_right_window"] == 2  # CLOSED
+        assert result["tailgate"] == 1  # OPEN
+        assert result["sunroof"] is None  # UNSPECIFIED(0) → None
+        assert result["alarm"] == 2  # TRIGGERED
+
+    def test_empty_response(self):
+        result = _parse_exterior_response(b"")
+        assert result["central_lock"] is None
+        assert result["front_left_door"] is None
+        assert result["alarm"] is None
+        assert len(result) == 14  # all 14 fields present
+
+    def test_missing_state_submessage(self):
+        """Response with VIN but no field 3 returns all None."""
+        data = _encode_field_bytes(2, TEST_VIN.encode("utf-8"))
+        result = _parse_exterior_response(data)
+        assert result["central_lock"] is None
+        assert result["front_left_door"] is None
+        assert result["alarm"] is None
+
+    def test_two_level_envelope(self):
+        """Verify outer envelope has field 2=VIN and field 3=ExteriorState."""
+        outer = _decode_message(EXTERIOR_ALL_LOCKED)
+        assert outer[2][0] == TEST_VIN.encode("utf-8")
+        assert isinstance(outer[3][0], (bytes, bytearray))
+        state = _get_submessage(outer, 3)
+        assert state is not None
+        assert 2 in state  # central_lock field

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -251,14 +251,14 @@ def _build_exterior_payload(vin: str, field_values: dict[int, int]) -> bytes:
 EXTERIOR_ALL_LOCKED = _build_exterior_payload(
     TEST_VIN,
     {
-        2: 2,   # central_lock: LOCKED
-        3: 2,   # front_left_door: CLOSED
-        4: 2,   # front_right_door: CLOSED
-        5: 2,   # rear_left_door: CLOSED
-        6: 2,   # rear_right_door: CLOSED
-        7: 2,   # front_left_window: CLOSED
-        8: 2,   # front_right_window: CLOSED
-        9: 2,   # rear_left_window: CLOSED
+        2: 2,  # central_lock: LOCKED
+        3: 2,  # front_left_door: CLOSED
+        4: 2,  # front_right_door: CLOSED
+        5: 2,  # rear_left_door: CLOSED
+        6: 2,  # rear_right_door: CLOSED
+        7: 2,  # front_left_window: CLOSED
+        8: 2,  # front_right_window: CLOSED
+        9: 2,  # rear_left_window: CLOSED
         10: 2,  # rear_right_window: CLOSED
         11: 2,  # hood: CLOSED
         12: 2,  # tailgate: CLOSED
@@ -271,14 +271,14 @@ EXTERIOR_ALL_LOCKED = _build_exterior_payload(
 EXTERIOR_MIXED = _build_exterior_payload(
     TEST_VIN,
     {
-        2: 1,   # central_lock: UNLOCKED
-        3: 1,   # front_left_door: OPEN
-        4: 3,   # front_right_door: AJAR
-        5: 2,   # rear_left_door: CLOSED
-        6: 2,   # rear_right_door: CLOSED
-        7: 1,   # front_left_window: OPEN
-        8: 2,   # front_right_window: CLOSED
-        9: 2,   # rear_left_window: CLOSED
+        2: 1,  # central_lock: UNLOCKED
+        3: 1,  # front_left_door: OPEN
+        4: 3,  # front_right_door: AJAR
+        5: 2,  # rear_left_door: CLOSED
+        6: 2,  # rear_right_door: CLOSED
+        7: 1,  # front_left_window: OPEN
+        8: 2,  # front_right_window: CLOSED
+        9: 2,  # rear_left_window: CLOSED
         10: 2,  # rear_right_window: CLOSED
         11: 2,  # hood: CLOSED
         12: 1,  # tailgate: OPEN


### PR DESCRIPTION
## Summary

- Add 14 binary sensors for vehicle exterior state using the CEP `ExteriorService/GetLatestExterior` gRPC endpoint
- Covers central lock, 4 doors, 4 windows, hood, tailgate, tank lid, sunroof, and alarm status
- Uses the same web client token and request format as existing climate/battery endpoints — no additional authentication needed

## Design decisions

- **binary_sensor platform** (not lock entity): Read-only state reporting — lock/unlock control is a separate future feature
- **5 entities enabled by default** (central lock + 4 doors), 9 disabled by default (windows, openings, alarm) to avoid UI clutter
- **UNSPECIFIED(0) → None**: Treated as unknown rather than open/closed. Cars without a sunroof report UNSPECIFIED, which correctly shows as unavailable
- **AJAR(3) → is_on=True**: Binary sensors can't distinguish open vs ajar, so both map to "open". The `raw_state` extra attribute preserves the distinction ("Open", "Closed", "Ajar", "Locked", "Unlocked", etc.)

## Changes

| File | Change |
|------|--------|
| `const.py` | `LOCK_STATUS_MAP`, `OPEN_STATUS_MAP`, `ALARM_STATUS_MAP` enum maps |
| `cep.py` | `get_exterior()` method + `_parse_exterior_response()` parser |
| `coordinator.py` | Fetch exterior data per VIN in `_do_fetch()` |
| `__init__.py` | Register `Platform.BINARY_SENSOR` |
| `binary_sensor.py` | New platform — 14 entity descriptions + entity class |
| `strings.json` / `en.json` | Translation keys for all 14 entities |
| `conftest.py` | `sample_exterior` fixture |
| `test_cep.py` | 5 exterior parser tests |
| `test_binary_sensor.py` | 29 entity tests (is_on logic, attributes, device classes, None handling) |

## Test plan

- [x] All 165 tests pass
- [x] Ruff linting clean
- [x] Verified against real API — all fields parse correctly from live ExteriorService response