### PR TITLE
Fix SetTargetSoc by adding required setting_type field

### DIFF
--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -426,8 +426,12 @@ class PolestarCoordinator(DataUpdateCoordinator):
         self._pccs_api.access_token = entry.data.get("pccs_access_token")
         self._pccs_api.refresh_token = entry.data.get("pccs_refresh_token")
 
-        # PCCS chronos services (charge timer, target SOC) accept the web token
-        self.pccs = PccsClient(self.api.access_token or "")
+        # PCCS chronos services accept the web token for reads;
+        # writes require the PCCS 2FA token (customer:attributes:write scope).
+        self.pccs = PccsClient(
+            access_token=self.api.access_token or "",
+            write_access_token=self._pccs_api.access_token,
+        )
         self.cep = CepClient(self.api.access_token or "")
         self._email: str = entry.data["email"]
         self._password: str = entry.data["password"]
@@ -594,8 +598,9 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 "pccs_refresh_token": self._pccs_api.refresh_token,
             },
         )
-        # Keep gRPC client tokens in sync (both use web token)
+        # Keep gRPC client tokens in sync
         self.pccs.access_token = self.api.access_token or ""
+        self.pccs.write_access_token = self._pccs_api.access_token
         self.cep.access_token = self.api.access_token or ""
 
     def close(self) -> None:

--- a/custom_components/polestar_soc/number.py
+++ b/custom_components/polestar_soc/number.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import logging
 
+import grpc
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -85,7 +87,10 @@ class PolestarChargeLimitNumber(CoordinatorEntity[PolestarCoordinator], NumberEn
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the charge limit percentage via PCCS."""
-        await self.hass.async_add_executor_job(
-            self.coordinator.pccs.set_target_soc, self._vin, int(value)
-        )
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.pccs.set_target_soc, self._vin, int(value)
+            )
+        except grpc.RpcError as err:
+            raise HomeAssistantError(f"Failed to set charge limit: {err}") from err
         await self.coordinator.async_request_refresh()

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -248,6 +248,8 @@ class PccsClient:
         back to the regular read token.
         """
         token = self._write_access_token or self._access_token
+        if not self._write_access_token:
+            _LOGGER.debug("No PCCS write token available, falling back to web token")
         return [
             ("authorization", f"Bearer {token}"),
             ("vin", vin),

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -74,10 +74,18 @@ def _build_get_request(vin: str) -> bytes:
     return _encode_field_bytes(1, _build_chronos_request(vin))
 
 
-def _build_set_target_soc_request(vin: str, target_soc: int) -> bytes:
-    """Build SetTargetSoc request bytes."""
+def _build_set_target_soc_request(vin: str, target_soc: int, setting_type: int = 3) -> bytes:
+    """Build SetTargetSoc request bytes.
+
+    Args:
+        vin: Vehicle identification number.
+        target_soc: Target state of charge percentage (e.g. 80).
+        setting_type: ChargeTargetLevelSettingType enum value.
+            1=DAILY, 2=LONG_TRIP, 3=CUSTOM (default).
+    """
     msg = _encode_field_bytes(1, _build_chronos_request(vin))
     msg += _encode_field_varint(2, target_soc)
+    msg += _encode_field_varint(3, setting_type)
     return msg
 
 
@@ -190,11 +198,17 @@ def _parse_charge_timer_response(data: bytes) -> dict:
 
 
 class PccsClient:
-    """Client for the PCCS gRPC API."""
+    """Client for the PCCS gRPC API.
 
-    def __init__(self, access_token: str) -> None:
-        """Initialize with an OAuth access token."""
+    Uses two tokens: ``access_token`` for read operations (web client token,
+    auto-refreshable) and ``write_access_token`` for write operations (PCCS
+    2FA token with ``customer:attributes:write`` scope).
+    """
+
+    def __init__(self, access_token: str, write_access_token: str | None = None) -> None:
+        """Initialize with OAuth access tokens."""
         self._access_token = access_token
+        self._write_access_token = write_access_token
         self._channel: grpc.Channel | None = None
 
     @property
@@ -205,6 +219,14 @@ class PccsClient:
     def access_token(self, value: str) -> None:
         self._access_token = value
 
+    @property
+    def write_access_token(self) -> str | None:
+        return self._write_access_token
+
+    @write_access_token.setter
+    def write_access_token(self, value: str | None) -> None:
+        self._write_access_token = value
+
     def _get_channel(self) -> grpc.Channel:
         """Get or create the gRPC channel."""
         if self._channel is None:
@@ -213,9 +235,21 @@ class PccsClient:
         return self._channel
 
     def _metadata(self, vin: str) -> list[tuple[str, str]]:
-        """Build gRPC call metadata."""
+        """Build gRPC call metadata for read operations."""
         return [
             ("authorization", f"Bearer {self._access_token}"),
+            ("vin", vin),
+        ]
+
+    def _write_metadata(self, vin: str) -> list[tuple[str, str]]:
+        """Build gRPC call metadata for write operations.
+
+        Uses the write token (PCCS 2FA) when available, otherwise falls
+        back to the regular read token.
+        """
+        token = self._write_access_token or self._access_token
+        return [
+            ("authorization", f"Bearer {token}"),
             ("vin", vin),
         ]
 
@@ -252,6 +286,7 @@ class PccsClient:
         """Set the charge target SOC for a vehicle.
 
         SetTargetSoc is a server-streaming RPC; we take the first response.
+        Requires the PCCS 2FA token (customer:attributes:write scope).
         """
         channel = self._get_channel()
         method = channel.unary_stream(
@@ -261,7 +296,7 @@ class PccsClient:
         )
         request = _build_set_target_soc_request(vin, percentage)
         try:
-            responses = method(request, metadata=self._metadata(vin), timeout=30)
+            responses = method(request, metadata=self._write_metadata(vin), timeout=30)
             for response in responses:
                 return _parse_target_soc_response(response)
             return _parse_target_soc_response(b"")
@@ -305,6 +340,7 @@ class PccsClient:
         """Set the global charge timer for a vehicle.
 
         SetGlobalChargeTimer is a server-streaming RPC; we take the first response.
+        Requires the PCCS 2FA token (customer:attributes:write scope).
         """
         channel = self._get_channel()
         method = channel.unary_stream(
@@ -314,7 +350,7 @@ class PccsClient:
         )
         request = _build_set_charge_timer_request(vin, start_hour, start_min, end_hour, end_min)
         try:
-            responses = method(request, metadata=self._metadata(vin), timeout=30)
+            responses = method(request, metadata=self._write_metadata(vin), timeout=30)
             for response in responses:
                 return _parse_charge_timer_response(response)
             return _parse_charge_timer_response(b"")

--- a/custom_components/polestar_soc/time.py
+++ b/custom_components/polestar_soc/time.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import logging
 from datetime import time
 
+import grpc
 from homeassistant.components.time import TimeEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -111,12 +113,15 @@ class PolestarChargeTimeEntity(CoordinatorEntity[PolestarCoordinator], TimeEntit
             start_m = timer_data.get("start_min") or 0
             end_h, end_m = value.hour, value.minute
 
-        await self.hass.async_add_executor_job(
-            self.coordinator.pccs.set_global_charge_timer,
-            self._vin,
-            start_h,
-            start_m,
-            end_h,
-            end_m,
-        )
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.pccs.set_global_charge_timer,
+                self._vin,
+                start_h,
+                start_m,
+                end_h,
+                end_m,
+            )
+        except grpc.RpcError as err:
+            raise HomeAssistantError(f"Failed to set charge timer: {err}") from err
         await self.coordinator.async_request_refresh()

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -7,6 +7,7 @@ from custom_components.polestar_soc.pccs import (
     _METHOD_GET_TARGET_SOC,
     _METHOD_SET_CHARGE_TIMER,
     _METHOD_SET_TARGET_SOC,
+    PccsClient,
     _build_set_charge_timer_request,
     _build_set_target_soc_request,
     _build_time_of_day,
@@ -220,6 +221,14 @@ class TestBuildSetTargetSocRequest:
         assert chronos[2] == [b"TESTVIN123"]
         # Field 2 is the target SOC value
         assert fields[2] == [80]
+        # Field 3 is the setting type (default CUSTOM=3)
+        assert fields[3] == [3]
+
+    def test_custom_setting_type(self):
+        data = _build_set_target_soc_request("TESTVIN123", 80, setting_type=1)
+        fields = _decode_message(data)
+        assert fields[2] == [80]
+        assert fields[3] == [1]
 
 
 class TestBuildTimeOfDay:
@@ -325,3 +334,45 @@ class TestParseChargeTimerResponse:
         assert result["end_hour"] == 7
         assert result["end_min"] == 0
         assert result["is_departure_active"] is False
+
+
+# ---------------------------------------------------------------------------
+# PccsClient write token
+# ---------------------------------------------------------------------------
+
+
+class TestPccsClientWriteToken:
+    def test_default_write_token_is_none(self):
+        client = PccsClient("read-token")
+        assert client.write_access_token is None
+
+    def test_write_token_set_via_constructor(self):
+        client = PccsClient("read-token", write_access_token="write-token")
+        assert client.write_access_token == "write-token"
+
+    def test_write_token_setter(self):
+        client = PccsClient("read-token")
+        client.write_access_token = "new-write-token"
+        assert client.write_access_token == "new-write-token"
+
+    def test_read_metadata_uses_read_token(self):
+        client = PccsClient("read-token", write_access_token="write-token")
+        meta = client._metadata("TESTVIN")
+        assert ("authorization", "Bearer read-token") in meta
+        assert ("vin", "TESTVIN") in meta
+
+    def test_write_metadata_uses_write_token(self):
+        client = PccsClient("read-token", write_access_token="write-token")
+        meta = client._write_metadata("TESTVIN")
+        assert ("authorization", "Bearer write-token") in meta
+        assert ("vin", "TESTVIN") in meta
+
+    def test_write_metadata_falls_back_to_read_token(self):
+        client = PccsClient("read-token")
+        meta = client._write_metadata("TESTVIN")
+        assert ("authorization", "Bearer read-token") in meta
+
+    def test_write_metadata_falls_back_when_empty_string(self):
+        client = PccsClient("read-token", write_access_token="")
+        meta = client._write_metadata("TESTVIN")
+        assert ("authorization", "Bearer read-token") in meta


### PR DESCRIPTION
## Summary

- Fix `SetTargetSoc` gRPC request by adding the required `chargeTargetLevelSettingType` field (field 3). The server was rejecting requests with "Setting type needs to be provided". Defaults to `CUSTOM` (3).
- Add `write_access_token` support to `PccsClient` — prefers PCCS 2FA token for write operations, falls back to web token.
- Wrap `grpc.RpcError` in `HomeAssistantError` in charge limit (`number.py`) and charge timer (`time.py`) entities for user-visible error messages.

## Test plan

- [x] Unit tests pass (173 tests)
- [x] Verified against live API: `SetTargetSoc` succeeds and value persists on re-read
- [x] Ruff lint and format clean