### PR TITLE
Fix SetGlobalChargeTimer request structure and response parsing

### DIFF
--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -14,6 +14,7 @@ import logging
 import uuid
 
 import grpc
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import PCCS_API_HOST
 from .proto import (
@@ -28,6 +29,19 @@ from .proto import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# ResponseStatus enum values from SetGlobalChargeTimerResponse
+_RESPONSE_STATUS_NAMES = {
+    0: "UNKNOWN_ERROR",
+    1: "SUCCESS",
+    2: "VALIDATION_ERROR",
+    3: "INTERNAL_ERROR",
+}
+
+
+class PccsError(HomeAssistantError):
+    """Error returned by the PCCS server (non-SUCCESS response status)."""
+
 
 # gRPC service method paths
 _SVC_TARGET_SOC = "/pccs.chronos.services.v1.TargetSocService"
@@ -105,11 +119,27 @@ def _build_set_charge_timer_request(
     start_min: int,
     end_hour: int,
     end_min: int,
+    activated: bool = True,
 ) -> bytes:
-    """Build SetGlobalChargeTimer request bytes."""
+    """Build SetGlobalChargeTimer request bytes.
+
+    Args:
+        vin: Vehicle identification number.
+        start_hour: Charging start hour (0-23).
+        start_min: Charging start minute (0-59).
+        end_hour: Charging end hour (0-23).
+        end_min: Charging end minute (0-59).
+        activated: Whether the charge timer is enabled (default True).
+    """
+    # Build GlobalChargeTimer sub-message: {1: start, 2: stop, 3: activated}
+    timer = b""
+    timer += _encode_field_bytes(1, _build_time_of_day(start_hour, start_min))
+    timer += _encode_field_bytes(2, _build_time_of_day(end_hour, end_min))
+    if activated:
+        timer += _encode_field_varint(3, 1)
+
     msg = _encode_field_bytes(1, _build_chronos_request(vin))
-    msg += _encode_field_bytes(2, _build_time_of_day(start_hour, start_min))
-    msg += _encode_field_bytes(3, _build_time_of_day(end_hour, end_min))
+    msg += _encode_field_bytes(2, timer)
     return msg
 
 
@@ -151,7 +181,7 @@ def _parse_target_soc_response(data: bytes) -> dict:
 
 
 def _parse_charge_timer_response(data: bytes) -> dict:
-    """Parse GetGlobalChargeTimerStream / SetGlobalChargeTimer response.
+    """Parse GetGlobalChargeTimerResponse.
 
     Response structure (verified against live API 2026-03-11):
         field 1: globalChargeTimer (message)     — current timer data
@@ -189,6 +219,37 @@ def _parse_charge_timer_response(data: bytes) -> dict:
         "end_hour": _get_int(end_time, 1) if end_time else None,
         "end_min": _get_int(end_time, 2) if end_time else None,
         "is_departure_active": _get_bool(timer, 3),
+    }
+
+
+def _parse_set_charge_timer_response(data: bytes) -> dict:
+    """Parse SetGlobalChargeTimerResponse.
+
+    Response structure:
+        field 1: id (string)           — echoed request UUID
+        field 2: status (varint enum)  — 0=UNKNOWN_ERROR, 1=SUCCESS,
+                                         2=VALIDATION_ERROR, 3=INTERNAL_ERROR
+        field 3: message (string)      — error message text
+        field 4: has_not_changed (bool) — true if values were already set
+    """
+    if not data:
+        return {"id": "", "status": 0, "message": "", "has_not_changed": False}
+
+    fields = _decode_message(data)
+
+    id_val = fields.get(1, [b""])[0]
+    if isinstance(id_val, bytes):
+        id_val = id_val.decode("utf-8", errors="replace")
+
+    msg_val = fields.get(3, [b""])[0]
+    if isinstance(msg_val, bytes):
+        msg_val = msg_val.decode("utf-8", errors="replace")
+
+    return {
+        "id": id_val,
+        "status": _get_int(fields, 2, 0),
+        "message": msg_val,
+        "has_not_changed": _get_bool(fields, 4),
     }
 
 
@@ -338,11 +399,14 @@ class PccsClient:
         start_min: int,
         end_hour: int,
         end_min: int,
+        activated: bool = True,
     ) -> dict:
         """Set the global charge timer for a vehicle.
 
-        SetGlobalChargeTimer is a server-streaming RPC; we take the first response.
         Requires the PCCS 2FA token (customer:attributes:write scope).
+
+        Args:
+            activated: Whether the charge timer should be enabled.
         """
         channel = self._get_channel()
         method = channel.unary_stream(
@@ -350,12 +414,30 @@ class PccsClient:
             request_serializer=_identity_serialize,
             response_deserializer=_identity_deserialize,
         )
-        request = _build_set_charge_timer_request(vin, start_hour, start_min, end_hour, end_min)
+        request = _build_set_charge_timer_request(
+            vin, start_hour, start_min, end_hour, end_min, activated=activated
+        )
         try:
             responses = method(request, metadata=self._write_metadata(vin), timeout=30)
             for response in responses:
-                return _parse_charge_timer_response(response)
-            return _parse_charge_timer_response(b"")
+                result = _parse_set_charge_timer_response(response)
+                break
+            else:
+                result = _parse_set_charge_timer_response(b"")
         except grpc.RpcError as err:
             _LOGGER.warning("PCCS SetGlobalChargeTimer failed: %s", err)
             raise
+
+        status = result.get("status", 0)
+        if status != 1:  # Not SUCCESS
+            status_name = _RESPONSE_STATUS_NAMES.get(status, f"STATUS_{status}")
+            server_msg = result.get("message", "")
+            msg = f"SetGlobalChargeTimer failed: {status_name}"
+            if server_msg:
+                msg += f" - {server_msg}"
+            raise PccsError(msg)
+
+        if result.get("has_not_changed"):
+            _LOGGER.debug("SetGlobalChargeTimer: values unchanged")
+
+        return result

--- a/custom_components/polestar_soc/time.py
+++ b/custom_components/polestar_soc/time.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import PolestarCoordinator
+from .pccs import PccsError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,6 +104,7 @@ class PolestarChargeTimeEntity(CoordinatorEntity[PolestarCoordinator], TimeEntit
         so we read the current opposite value from coordinator data.
         """
         timer_data = self.coordinator.data.get("charge_timer", {}).get(self._vin) or {}
+        activated = timer_data.get("is_departure_active", True)
 
         if self._time_key == "start":
             start_h, start_m = value.hour, value.minute
@@ -121,7 +123,8 @@ class PolestarChargeTimeEntity(CoordinatorEntity[PolestarCoordinator], TimeEntit
                 start_m,
                 end_h,
                 end_m,
+                activated,
             )
-        except grpc.RpcError as err:
+        except (grpc.RpcError, PccsError) as err:
             raise HomeAssistantError(f"Failed to set charge timer: {err}") from err
         await self.coordinator.async_request_refresh()

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -12,6 +12,7 @@ from custom_components.polestar_soc.pccs import (
     _build_set_target_soc_request,
     _build_time_of_day,
     _parse_charge_timer_response,
+    _parse_set_charge_timer_response,
     _parse_target_soc_response,
 )
 from custom_components.polestar_soc.proto import (
@@ -253,13 +254,46 @@ class TestBuildTimeOfDay:
 
 
 class TestBuildSetChargeTimerRequest:
-    def test_has_start_and_end(self):
+    def test_nested_structure(self):
         data = _build_set_charge_timer_request("TESTVIN123", 22, 0, 6, 30)
         fields = _decode_message(data)
-        # Field 1 is ChronosRequest, 2 is start time, 3 is end time
+        # Field 1 is ChronosRequest, field 2 is GlobalChargeTimer sub-message
         assert 1 in fields
         assert 2 in fields
-        assert 3 in fields
+        # Times should NOT be at top level (old bug: fields 2 and 3 were times)
+        assert 3 not in fields
+
+        # Decode the GlobalChargeTimer sub-message
+        timer = _get_submessage(fields, 2)
+        assert timer is not None
+        # Field 1 = start DailyTime, field 2 = stop DailyTime, field 3 = activated
+        start = _get_submessage(timer, 1)
+        stop = _get_submessage(timer, 2)
+        assert start is not None
+        assert stop is not None
+        assert _get_int(start, 1) == 22
+        assert _get_int(stop, 1) == 6
+        assert _get_int(stop, 2) == 30
+        # Default activated=True
+        assert _get_bool(timer, 3) is True
+
+    def test_activated_false(self):
+        data = _build_set_charge_timer_request("TESTVIN123", 22, 0, 6, 30, activated=False)
+        fields = _decode_message(data)
+        timer = _get_submessage(fields, 2)
+        assert timer is not None
+        # activated=False → field 3 omitted (proto3 default)
+        assert _get_bool(timer, 3) is False
+
+    def test_midnight_times(self):
+        """Verify 00:00 start/stop times work (zero-value edge case)."""
+        data = _build_set_charge_timer_request("TESTVIN123", 0, 0, 0, 0)
+        fields = _decode_message(data)
+        timer = _get_submessage(fields, 2)
+        assert timer is not None
+        # Start and stop DailyTime messages should still be present (empty = 00:00)
+        assert 1 in timer
+        assert 2 in timer
 
 
 # ---------------------------------------------------------------------------
@@ -334,6 +368,46 @@ class TestParseChargeTimerResponse:
         assert result["end_hour"] == 7
         assert result["end_min"] == 0
         assert result["is_departure_active"] is False
+
+
+class TestParseSetChargeTimerResponse:
+    def test_empty_data(self):
+        result = _parse_set_charge_timer_response(b"")
+        assert result["id"] == ""
+        assert result["status"] == 0
+        assert result["message"] == ""
+        assert result["has_not_changed"] is False
+
+    def test_success(self):
+        data = (
+            _encode_field_bytes(1, b"test-uuid")
+            + _encode_field_varint(2, 1)  # SUCCESS
+        )
+        result = _parse_set_charge_timer_response(data)
+        assert result["id"] == "test-uuid"
+        assert result["status"] == 1
+        assert result["message"] == ""
+        assert result["has_not_changed"] is False
+
+    def test_validation_error(self):
+        data = (
+            _encode_field_bytes(1, b"test-uuid")
+            + _encode_field_varint(2, 2)  # VALIDATION_ERROR
+            + _encode_field_bytes(3, b"Invalid time range")
+        )
+        result = _parse_set_charge_timer_response(data)
+        assert result["status"] == 2
+        assert result["message"] == "Invalid time range"
+
+    def test_has_not_changed(self):
+        data = (
+            _encode_field_bytes(1, b"test-uuid")
+            + _encode_field_varint(2, 1)  # SUCCESS
+            + _encode_field_varint(4, 1)  # has_not_changed=True
+        )
+        result = _parse_set_charge_timer_response(data)
+        assert result["status"] == 1
+        assert result["has_not_changed"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -380,8 +380,7 @@ class TestParseSetChargeTimerResponse:
 
     def test_success(self):
         data = (
-            _encode_field_bytes(1, b"test-uuid")
-            + _encode_field_varint(2, 1)  # SUCCESS
+            _encode_field_bytes(1, b"test-uuid") + _encode_field_varint(2, 1)  # SUCCESS
         )
         result = _parse_set_charge_timer_response(data)
         assert result["id"] == "test-uuid"


### PR DESCRIPTION
## Summary

- Fix `SetGlobalChargeTimer` request by nesting start/end times inside a `GlobalChargeTimer` sub-message (field 2) instead of placing them as top-level fields. The server was rejecting the old structure.
- Add `activated` boolean field to the charge timer request, preserving the current timer activation state when changing times.
- Add `_parse_set_charge_timer_response()` for the Set response format (`{id, status, message, has_not_changed}`) — previously the Get response parser was incorrectly reused.
- Add `PccsError` exception class for server-returned errors; raise on non-SUCCESS status with descriptive message.
- Update `time.py` to pass `activated` state and catch `PccsError` alongside `grpc.RpcError`.

## Test plan

- [x] Unit tests pass (56 tests)
- [x] Verified against live API: SetGlobalChargeTimer succeeds with correct response parsing
- [x] Ruff lint clean