### PR TITLE
Add charging timer switch entity

### DIFF
--- a/custom_components/polestar_soc/__init__.py
+++ b/custom_components/polestar_soc/__init__.py
@@ -13,6 +13,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.NUMBER,
     Platform.TIME,
+    Platform.SWITCH,
     Platform.DEVICE_TRACKER,
     Platform.BINARY_SENSOR,
 ]

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -183,14 +183,19 @@ def _parse_target_soc_response(data: bytes) -> dict:
 def _parse_charge_timer_response(data: bytes) -> dict:
     """Parse GetGlobalChargeTimerResponse.
 
-    Response structure (verified against live API 2026-03-11):
-        field 1: globalChargeTimer (message)     — current timer data
-        field 3: updatedAt (varint)              — server timestamp
+    Response structure (verified against live API 2026-03-14):
+        field 1: globalChargeTimer (message)        — baseline timer data
+        field 2: pendingGlobalChargeTimer (message)  — most recent write (if any)
+        field 3: updatedAt (varint)                  — server timestamp
+
+    When a write has been issued, field 2 holds the pending values while
+    field 1 retains the baseline.  We prefer field 2 when present so that
+    the UI reflects the most recently requested state immediately.
 
     GlobalChargeTimer sub-message:
         field 1: startTime (TimeOfDay message)   — {1: hours, 2: minutes, 3: tz}
         field 2: endTime (TimeOfDay message)     — {1: hours, 2: minutes, 3: tz}
-        field 3: isDepartureTimeActive (bool)
+        field 3: activated (bool)
         field 4: metadata (message)              — {1: id, 2: timestamp, 3: source}
     """
     empty = {
@@ -205,8 +210,8 @@ def _parse_charge_timer_response(data: bytes) -> dict:
 
     envelope = _decode_message(data)
 
-    # GlobalChargeTimer is in field 1 of the response envelope
-    timer = _get_submessage(envelope, 1)
+    # Prefer pending timer (field 2) over baseline (field 1)
+    timer = _get_submessage(envelope, 2) or _get_submessage(envelope, 1)
     if not timer:
         return empty
 

--- a/custom_components/polestar_soc/strings.json
+++ b/custom_components/polestar_soc/strings.json
@@ -85,6 +85,11 @@
         "name": "Charging end time"
       }
     },
+    "switch": {
+      "charging_timer": {
+        "name": "Charging timer"
+      }
+    },
     "device_tracker": {
       "location": {
         "name": "Location"

--- a/custom_components/polestar_soc/switch.py
+++ b/custom_components/polestar_soc/switch.py
@@ -1,0 +1,112 @@
+"""Switch platform for Polestar State of Charge — charging timer toggle."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import grpc
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import PolestarCoordinator
+from .pccs import PccsError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Polestar switch entities from a config entry."""
+    coordinator: PolestarCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities: list[PolestarChargeTimerSwitch] = []
+    for vehicle in coordinator.data.get("vehicles", []):
+        vin = vehicle["vin"]
+        entities.append(PolestarChargeTimerSwitch(coordinator, vehicle, vin))
+
+    async_add_entities(entities)
+
+
+class PolestarChargeTimerSwitch(CoordinatorEntity[PolestarCoordinator], SwitchEntity):
+    """Charging timer switch — enables or disables the scheduled charging window."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "charging_timer"
+    _attr_icon = "mdi:timer-outline"
+
+    def __init__(
+        self,
+        coordinator: PolestarCoordinator,
+        vehicle: dict,
+        vin: str,
+    ) -> None:
+        """Initialize the charging timer switch entity."""
+        super().__init__(coordinator)
+        self._vin = vin
+        self._attr_unique_id = f"{vin}_charging_timer"
+
+        model_name = "Polestar"
+        content = vehicle.get("content")
+        if content and content.get("model"):
+            model_name = content["model"].get("name", model_name)
+        year = vehicle.get("modelYear", "")
+        device_name = f"{model_name} ({year})" if year else model_name
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vin)},
+            name=device_name,
+            manufacturer="Polestar",
+            model=model_name,
+            sw_version=str(year) if year else None,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the charging timer is active."""
+        data = self.coordinator.data
+        if not data:
+            return None
+        timer_data = data.get("charge_timer", {}).get(self._vin)
+        if timer_data is None:
+            return None
+        return timer_data.get("is_departure_active")
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable the charging timer."""
+        await self._set_activated(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable the charging timer."""
+        await self._set_activated(False)
+
+    async def _set_activated(self, activated: bool) -> None:
+        """Set the charging timer activated state, preserving current times."""
+        timer_data = self.coordinator.data.get("charge_timer", {}).get(self._vin) or {}
+        start_h = timer_data.get("start_hour") or 0
+        start_m = timer_data.get("start_min") or 0
+        end_h = timer_data.get("end_hour") or 0
+        end_m = timer_data.get("end_min") or 0
+
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.pccs.set_global_charge_timer,
+                self._vin,
+                start_h,
+                start_m,
+                end_h,
+                end_m,
+                activated,
+            )
+        except (grpc.RpcError, PccsError) as err:
+            raise HomeAssistantError(f"Failed to set charging timer: {err}") from err
+        await self.coordinator.async_request_refresh()

--- a/custom_components/polestar_soc/translations/en.json
+++ b/custom_components/polestar_soc/translations/en.json
@@ -85,6 +85,11 @@
         "name": "Charging end time"
       }
     },
+    "switch": {
+      "charging_timer": {
+        "name": "Charging timer"
+      }
+    },
     "device_tracker": {
       "location": {
         "name": "Location"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,18 @@ def sample_location():
 
 
 @pytest.fixture
+def sample_charge_timer():
+    """Return a sample charge timer dict."""
+    return {
+        "start_hour": 22,
+        "start_min": 0,
+        "end_hour": 6,
+        "end_min": 30,
+        "is_departure_active": True,
+    }
+
+
+@pytest.fixture
 def sample_coordinator_data(
     sample_vehicle,
     sample_battery,

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -354,6 +354,28 @@ class TestParseChargeTimerResponse:
         assert result["end_min"] == 0
         assert result["is_departure_active"] is False
 
+    def test_pending_timer_preferred_over_baseline(self):
+        """Field 2 (pending) should be preferred over field 1 (baseline)."""
+        baseline_start = _build_time_of_day(22, 0)
+        baseline_end = _build_time_of_day(6, 0)
+        baseline = _encode_field_bytes(1, baseline_start) + _encode_field_bytes(2, baseline_end)
+
+        pending_start = _build_time_of_day(23, 30)
+        pending_end = _build_time_of_day(7, 15)
+        pending = (
+            _encode_field_bytes(1, pending_start)
+            + _encode_field_bytes(2, pending_end)
+            + _encode_field_varint(3, 1)  # activated=True
+        )
+
+        data = _encode_field_bytes(1, baseline) + _encode_field_bytes(2, pending)
+        result = _parse_charge_timer_response(data)
+        assert result["start_hour"] == 23
+        assert result["start_min"] == 30
+        assert result["end_hour"] == 7
+        assert result["end_min"] == 15
+        assert result["is_departure_active"] is True
+
     def test_with_timezone_in_time_of_day(self):
         """TimeOfDay may include a timezone sub-message in field 3."""
         # Build TimeOfDay with extra field 3 (timezone offset sub-message)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,159 @@
+"""Tests for switch platform — charging timer toggle."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import grpc
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.polestar_soc.const import DOMAIN
+from custom_components.polestar_soc.pccs import PccsError
+from custom_components.polestar_soc.switch import PolestarChargeTimerSwitch
+
+VIN = "YSMYKEAE1RB000001"
+
+
+def _make_switch(
+    coordinator_data: dict | None,
+    vehicle: dict,
+    vin: str = VIN,
+) -> PolestarChargeTimerSwitch:
+    """Create a PolestarChargeTimerSwitch with a mock coordinator."""
+    coordinator = MagicMock()
+    coordinator.data = coordinator_data
+    coordinator.async_request_refresh = AsyncMock()
+    return PolestarChargeTimerSwitch(coordinator, vehicle, vin)
+
+
+@pytest.fixture
+def sample_charge_timer():
+    """Return a sample charge timer dict."""
+    return {
+        "start_hour": 22,
+        "start_min": 0,
+        "end_hour": 6,
+        "end_min": 30,
+        "is_departure_active": True,
+    }
+
+
+class TestIsOn:
+    def test_active(self, sample_coordinator_data, sample_vehicle, sample_charge_timer):
+        sample_coordinator_data["charge_timer"][VIN] = sample_charge_timer
+        switch = _make_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.is_on is True
+
+    def test_inactive(self, sample_coordinator_data, sample_vehicle, sample_charge_timer):
+        sample_charge_timer["is_departure_active"] = False
+        sample_coordinator_data["charge_timer"][VIN] = sample_charge_timer
+        switch = _make_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.is_on is False
+
+    def test_none_when_no_coordinator_data(self, sample_vehicle):
+        switch = _make_switch(None, sample_vehicle)
+        assert switch.is_on is None
+
+    def test_none_when_no_timer_data(self, sample_coordinator_data, sample_vehicle):
+        switch = _make_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.is_on is None
+
+
+class TestEntity:
+    def test_unique_id(self, sample_coordinator_data, sample_vehicle):
+        switch = _make_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.unique_id == f"{VIN}_charging_timer"
+
+    def test_translation_key(self, sample_coordinator_data, sample_vehicle):
+        switch = _make_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.translation_key == "charging_timer"
+
+    def test_device_info(self, sample_coordinator_data, sample_vehicle):
+        switch = _make_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.device_info["identifiers"] == {(DOMAIN, VIN)}
+        assert switch.device_info["manufacturer"] == "Polestar"
+
+
+class TestTurnOn:
+    @pytest.mark.asyncio
+    async def test_calls_set_with_activated_true(
+        self, sample_coordinator_data, sample_vehicle, sample_charge_timer
+    ):
+        sample_charge_timer["is_departure_active"] = False
+        sample_coordinator_data["charge_timer"][VIN] = sample_charge_timer
+        switch = _make_switch(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *args: fn(*args))
+        switch.hass = hass
+
+        await switch.async_turn_on()
+
+        switch.coordinator.pccs.set_global_charge_timer.assert_called_once_with(
+            VIN, 22, 0, 6, 30, True
+        )
+        switch.coordinator.async_request_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_grpc_error_raises_ha_error(
+        self, sample_coordinator_data, sample_vehicle, sample_charge_timer
+    ):
+        sample_coordinator_data["charge_timer"][VIN] = sample_charge_timer
+        switch = _make_switch(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=grpc.RpcError())
+        switch.hass = hass
+
+        with pytest.raises(HomeAssistantError, match="Failed to set charging timer"):
+            await switch.async_turn_on()
+
+    @pytest.mark.asyncio
+    async def test_pccs_error_raises_ha_error(
+        self, sample_coordinator_data, sample_vehicle, sample_charge_timer
+    ):
+        sample_coordinator_data["charge_timer"][VIN] = sample_charge_timer
+        switch = _make_switch(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=PccsError("timer failed"))
+        switch.hass = hass
+
+        with pytest.raises(HomeAssistantError, match="Failed to set charging timer"):
+            await switch.async_turn_on()
+
+
+class TestTurnOff:
+    @pytest.mark.asyncio
+    async def test_calls_set_with_activated_false(
+        self, sample_coordinator_data, sample_vehicle, sample_charge_timer
+    ):
+        sample_coordinator_data["charge_timer"][VIN] = sample_charge_timer
+        switch = _make_switch(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *args: fn(*args))
+        switch.hass = hass
+
+        await switch.async_turn_off()
+
+        switch.coordinator.pccs.set_global_charge_timer.assert_called_once_with(
+            VIN, 22, 0, 6, 30, False
+        )
+        switch.coordinator.async_request_refresh.assert_called_once()
+
+
+class TestMissingTimerData:
+    @pytest.mark.asyncio
+    async def test_defaults_times_to_zero(self, sample_coordinator_data, sample_vehicle):
+        """When no timer data exists, times default to 0."""
+        switch = _make_switch(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *args: fn(*args))
+        switch.hass = hass
+
+        await switch.async_turn_on()
+
+        switch.coordinator.pccs.set_global_charge_timer.assert_called_once_with(
+            VIN, 0, 0, 0, 0, True
+        )

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -25,18 +25,6 @@ def _make_switch(
     return PolestarChargeTimerSwitch(coordinator, vehicle, vin)
 
 
-@pytest.fixture
-def sample_charge_timer():
-    """Return a sample charge timer dict."""
-    return {
-        "start_hour": 22,
-        "start_min": 0,
-        "end_hour": 6,
-        "end_min": 30,
-        "is_departure_active": True,
-    }
-
-
 class TestIsOn:
     def test_active(self, sample_coordinator_data, sample_vehicle, sample_charge_timer):
         sample_coordinator_data["charge_timer"][VIN] = sample_charge_timer


### PR DESCRIPTION
## Summary

- Adds a `switch` platform entity that toggles the charging timer on/off, preserving the configured start/end times
- Fixes `GetGlobalChargeTimer` response parsing to prefer the pending timer state (field 2) over the baseline (field 1), so the UI reflects writes immediately
- Includes 12 unit tests covering state reads, toggle actions, error handling, and missing data edge cases

## Test plan

- [x] All 191 unit tests pass
- [x] ruff check and ruff format pass
- [x] Verified toggle on/off against live API — write succeeds and read-back reflects new state