### PR TITLE
Add climate pre-conditioning switch entity

### DIFF
--- a/custom_components/polestar_soc/const.py
+++ b/custom_components/polestar_soc/const.py
@@ -91,6 +91,25 @@ HEATING_INTENSITY_MAP: dict[int, str] = {
     3: "High",
 }
 
+# InvocationResponse status enum (InvocationService)
+INVOCATION_STATUS_MAP: dict[int, str] = {
+    0: "UNKNOWN_ERROR",
+    1: "SENT",
+    2: "CAR_OFFLINE",
+    4: "DELIVERED",
+    5: "DELIVERY_TIMEOUT",
+    6: "SUCCESS",
+    7: "RESPONSE_TIMEOUT",
+    8: "UNKNOWN_CAR_ERROR",
+    9: "NOT_ALLOWED_PRIVACY_ENABLED",
+    10: "NOT_ALLOWED_WRONG_USAGE_MODE",
+    11: "INVOCATION_SPECIFIC_ERROR",
+    12: "NOT_ALLOWED_CONFLICTING_INVOCATION",
+}
+
+# Intermediate statuses (command still in progress)
+_INVOCATION_INTERMEDIATE_STATUSES = {1, 4}  # SENT, DELIVERED
+
 # Exterior state enums (ExteriorService)
 LOCK_STATUS_MAP: dict[int, str | None] = {
     0: None,

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -57,6 +57,8 @@ _METHOD_SET_CHARGE_TIMER = f"{_SVC_CHARGE_TIMER}/SetGlobalChargeTimer"
 _METHOD_CLIMATIZATION_START = f"{_SVC_INVOCATION}/ClimatizationStart"
 _METHOD_CLIMATIZATION_STOP = f"{_SVC_INVOCATION}/ClimatizationStop"
 
+_INVOCATION_EXPIRY_MS = 120_000  # command expiry: 120 seconds
+
 
 # ---------------------------------------------------------------------------
 # Protobuf message builders
@@ -159,7 +161,7 @@ def _build_invocation_request(vin: str) -> bytes:
     msg = b""
     msg += _encode_field_bytes(1, str(uuid.uuid4()).encode("utf-8"))
     msg += _encode_field_bytes(2, vin.encode("utf-8"))
-    msg += _encode_field_varint(3, int(time.time() * 1000) + 120_000)
+    msg += _encode_field_varint(3, int(time.time() * 1000) + _INVOCATION_EXPIRY_MS)
     return msg
 
 

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -11,15 +11,17 @@ from __future__ import annotations
 
 import datetime
 import logging
+import time
 import uuid
 
 import grpc
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import PCCS_API_HOST
+from .const import _INVOCATION_INTERMEDIATE_STATUSES, INVOCATION_STATUS_MAP, PCCS_API_HOST
 from .proto import (
     _decode_message,
     _encode_field_bytes,
+    _encode_field_fixed32,
     _encode_field_varint,
     _get_bool,
     _get_int,
@@ -46,11 +48,14 @@ class PccsError(HomeAssistantError):
 # gRPC service method paths
 _SVC_TARGET_SOC = "/pccs.chronos.services.v1.TargetSocService"
 _SVC_CHARGE_TIMER = "/pccs.chronos.services.v2.GlobalChargeTimerService"
+_SVC_INVOCATION = "/pccs.invocation.v1.InvocationService"
 
 _METHOD_GET_TARGET_SOC = f"{_SVC_TARGET_SOC}/GetTargetSoc"
 _METHOD_SET_TARGET_SOC = f"{_SVC_TARGET_SOC}/SetTargetSoc"
 _METHOD_GET_CHARGE_TIMER = f"{_SVC_CHARGE_TIMER}/GetGlobalChargeTimerStream"
 _METHOD_SET_CHARGE_TIMER = f"{_SVC_CHARGE_TIMER}/SetGlobalChargeTimer"
+_METHOD_CLIMATIZATION_START = f"{_SVC_INVOCATION}/ClimatizationStart"
+_METHOD_CLIMATIZATION_STOP = f"{_SVC_INVOCATION}/ClimatizationStop"
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +146,81 @@ def _build_set_charge_timer_request(
     msg = _encode_field_bytes(1, _build_chronos_request(vin))
     msg += _encode_field_bytes(2, timer)
     return msg
+
+
+def _build_invocation_request(vin: str) -> bytes:
+    """Build an InvocationRequest sub-message.
+
+    InvocationRequest (pccs.invocation.v1):
+        field 1: id (string)                   — random UUID
+        field 2: vin (string)                  — vehicle VIN
+        field 3: expiration_timestamp (int64)  — Unix timestamp for command expiry
+    """
+    msg = b""
+    msg += _encode_field_bytes(1, str(uuid.uuid4()).encode("utf-8"))
+    msg += _encode_field_bytes(2, vin.encode("utf-8"))
+    msg += _encode_field_varint(3, int(time.time() * 1000) + 120_000)
+    return msg
+
+
+def _build_climatization_start_request(vin: str, temperature: float = 22.0) -> bytes:
+    """Build ClimatizationStartRequest bytes.
+
+    Args:
+        vin: Vehicle identification number.
+        temperature: Target cabin temperature in Celsius (default 22.0).
+    """
+    msg = _encode_field_bytes(1, _build_invocation_request(vin))
+    msg += _encode_field_varint(2, 1)  # start = true
+    msg += _encode_field_fixed32(3, temperature)
+    return msg
+
+
+def _build_climatization_stop_request(vin: str) -> bytes:
+    """Build ClimatizationStopRequest bytes."""
+    return _encode_field_bytes(1, _build_invocation_request(vin))
+
+
+def _parse_invocation_response(data: bytes) -> dict:
+    """Parse ClimatizationResponse → InvocationResponse.
+
+    ClimatizationResponse:
+        field 1: InvocationResponse (message)
+
+    InvocationResponse:
+        field 1: id (string)
+        field 2: vin (string)
+        field 3: status (varint enum)
+        field 4: message (string)
+        field 5: timestamp (int64)
+    """
+    empty = {"id": "", "vin": "", "status": 0, "message": ""}
+    if not data:
+        return empty
+
+    outer = _decode_message(data)
+    inner = _get_submessage(outer, 1)
+    if inner is None:
+        return empty
+
+    id_val = inner.get(1, [b""])[0]
+    if isinstance(id_val, bytes):
+        id_val = id_val.decode("utf-8", errors="replace")
+
+    vin_val = inner.get(2, [b""])[0]
+    if isinstance(vin_val, bytes):
+        vin_val = vin_val.decode("utf-8", errors="replace")
+
+    msg_val = inner.get(4, [b""])[0]
+    if isinstance(msg_val, bytes):
+        msg_val = msg_val.decode("utf-8", errors="replace")
+
+    return {
+        "id": id_val,
+        "vin": vin_val,
+        "status": _get_int(inner, 3, 0),
+        "message": msg_val,
+    }
 
 
 def _parse_target_soc_response(data: bytes) -> dict:
@@ -446,3 +526,69 @@ class PccsClient:
             _LOGGER.debug("SetGlobalChargeTimer: values unchanged")
 
         return result
+
+    # -- Climate (InvocationService) -----------------------------------------
+
+    def _send_invocation(self, vin: str, method_path: str, request: bytes) -> dict:
+        """Send an InvocationService command and wait for terminal status.
+
+        InvocationService methods are SERVER_STREAMING.  The stream emits
+        intermediate statuses (SENT, DELIVERED) before a terminal status
+        (SUCCESS or an error).  We iterate until we reach a terminal status.
+
+        The server may cancel the stream (~5s timeout) before SUCCESS
+        arrives.  If we received DELIVERED before cancellation, the command
+        was accepted by the vehicle and we treat it as success.
+        """
+        channel = self._get_channel()
+        method = channel.unary_stream(
+            method_path,
+            request_serializer=_identity_serialize,
+            response_deserializer=_identity_deserialize,
+        )
+        result = _parse_invocation_response(b"")
+        try:
+            responses = method(request, metadata=self._write_metadata(vin), timeout=60)
+            for response in responses:
+                result = _parse_invocation_response(response)
+                status = result.get("status", 0)
+                if status not in _INVOCATION_INTERMEDIATE_STATUSES:
+                    break
+        except grpc.RpcError as err:
+            # If the server cancelled the stream after DELIVERED, the
+            # command was accepted — treat as success.
+            if result.get("status") == 4:  # DELIVERED
+                _LOGGER.debug(
+                    "PCCS %s stream cancelled after DELIVERED — treating as success",
+                    method_path,
+                )
+                return result
+            _LOGGER.warning("PCCS %s failed: %s", method_path, err)
+            raise
+
+        status = result.get("status", 0)
+        if status not in (4, 6):  # Not DELIVERED or SUCCESS
+            status_name = INVOCATION_STATUS_MAP.get(status, f"STATUS_{status}")
+            server_msg = result.get("message", "")
+            msg = f"Climatization command failed: {status_name}"
+            if server_msg:
+                msg += f" - {server_msg}"
+            raise PccsError(msg)
+
+        return result
+
+    def climatization_start(self, vin: str, temperature: float = 22.0) -> dict:
+        """Start vehicle climate pre-conditioning.
+
+        Requires the PCCS 2FA token (customer:attributes:write scope).
+        """
+        request = _build_climatization_start_request(vin, temperature)
+        return self._send_invocation(vin, _METHOD_CLIMATIZATION_START, request)
+
+    def climatization_stop(self, vin: str) -> dict:
+        """Stop vehicle climate pre-conditioning.
+
+        Requires the PCCS 2FA token (customer:attributes:write scope).
+        """
+        request = _build_climatization_stop_request(vin)
+        return self._send_invocation(vin, _METHOD_CLIMATIZATION_STOP, request)

--- a/custom_components/polestar_soc/proto.py
+++ b/custom_components/polestar_soc/proto.py
@@ -37,6 +37,12 @@ def _encode_field_bytes(field_number: int, data: bytes) -> bytes:
     return _encode_varint(tag) + _encode_varint(len(data)) + data
 
 
+def _encode_field_fixed32(field_number: int, value: float) -> bytes:
+    """Encode a float field as fixed32 (tag + 4 bytes, IEEE 754 single-precision)."""
+    tag = (field_number << 3) | 5  # wire type 5
+    return _encode_varint(tag) + struct.pack("<f", value)
+
+
 # ---------------------------------------------------------------------------
 # Decoding
 # ---------------------------------------------------------------------------

--- a/custom_components/polestar_soc/strings.json
+++ b/custom_components/polestar_soc/strings.json
@@ -88,6 +88,9 @@
     "switch": {
       "charging_timer": {
         "name": "Charging timer"
+      },
+      "climate": {
+        "name": "Climate"
       }
     },
     "device_tracker": {

--- a/custom_components/polestar_soc/switch.py
+++ b/custom_components/polestar_soc/switch.py
@@ -20,6 +20,16 @@ from .pccs import PccsError
 
 _LOGGER = logging.getLogger(__name__)
 
+# Climate statuses that indicate pre-conditioning is active
+_CLIMATE_ACTIVE_STATUSES = {
+    "Starting",
+    "Pre-conditioning",
+    "Pre-conditioning (external power)",
+    "Pre-cleaning",
+    "Pre-conditioning and cleaning",
+    "Residual heat",
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -29,10 +39,11 @@ async def async_setup_entry(
     """Set up Polestar switch entities from a config entry."""
     coordinator: PolestarCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    entities: list[PolestarChargeTimerSwitch] = []
+    entities: list[SwitchEntity] = []
     for vehicle in coordinator.data.get("vehicles", []):
         vin = vehicle["vin"]
         entities.append(PolestarChargeTimerSwitch(coordinator, vehicle, vin))
+        entities.append(PolestarClimateSwitch(coordinator, vehicle, vin))
 
     async_add_entities(entities)
 
@@ -109,4 +120,74 @@ class PolestarChargeTimerSwitch(CoordinatorEntity[PolestarCoordinator], SwitchEn
             )
         except (grpc.RpcError, PccsError) as err:
             raise HomeAssistantError(f"Failed to set charging timer: {err}") from err
+        await self.coordinator.async_request_refresh()
+
+
+class PolestarClimateSwitch(CoordinatorEntity[PolestarCoordinator], SwitchEntity):
+    """Climate pre-conditioning switch — starts or stops cabin climate control."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "climate"
+    _attr_icon = "mdi:fan"
+
+    def __init__(
+        self,
+        coordinator: PolestarCoordinator,
+        vehicle: dict,
+        vin: str,
+    ) -> None:
+        """Initialize the climate switch entity."""
+        super().__init__(coordinator)
+        self._vin = vin
+        self._attr_unique_id = f"{vin}_climate"
+
+        model_name = "Polestar"
+        content = vehicle.get("content")
+        if content and content.get("model"):
+            model_name = content["model"].get("name", model_name)
+        year = vehicle.get("modelYear", "")
+        device_name = f"{model_name} ({year})" if year else model_name
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vin)},
+            name=device_name,
+            manufacturer="Polestar",
+            model=model_name,
+            sw_version=str(year) if year else None,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether climate pre-conditioning is active."""
+        data = self.coordinator.data
+        if not data:
+            return None
+        climate = data.get("climate", {}).get(self._vin)
+        if climate is None:
+            return None
+        status = climate.get("status")
+        if status is None:
+            return None
+        return status in _CLIMATE_ACTIVE_STATUSES
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Start climate pre-conditioning."""
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.pccs.climatization_start,
+                self._vin,
+            )
+        except (grpc.RpcError, PccsError) as err:
+            raise HomeAssistantError(f"Failed to start climate: {err}") from err
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Stop climate pre-conditioning."""
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.pccs.climatization_stop,
+                self._vin,
+            )
+        except (grpc.RpcError, PccsError) as err:
+            raise HomeAssistantError(f"Failed to stop climate: {err}") from err
         await self.coordinator.async_request_refresh()

--- a/custom_components/polestar_soc/switch.py
+++ b/custom_components/polestar_soc/switch.py
@@ -20,15 +20,10 @@ from .pccs import PccsError
 
 _LOGGER = logging.getLogger(__name__)
 
-# Climate statuses that indicate pre-conditioning is active
-_CLIMATE_ACTIVE_STATUSES = {
-    "Starting",
-    "Pre-conditioning",
-    "Pre-conditioning (external power)",
-    "Pre-cleaning",
-    "Pre-conditioning and cleaning",
-    "Residual heat",
-}
+# Climate statuses that indicate pre-conditioning is NOT active.
+# Any new status added to CLIMATE_RUNNING_STATUS_MAP will default to "active"
+# (conservative — switch shows as on, prompting the user to turn it off).
+_CLIMATE_INACTIVE_STATUSES = {"Unknown", "Off"}
 
 
 async def async_setup_entry(
@@ -168,7 +163,7 @@ class PolestarClimateSwitch(CoordinatorEntity[PolestarCoordinator], SwitchEntity
         status = climate.get("status")
         if status is None:
             return None
-        return status in _CLIMATE_ACTIVE_STATUSES
+        return status not in _CLIMATE_INACTIVE_STATUSES
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Start climate pre-conditioning."""

--- a/custom_components/polestar_soc/translations/en.json
+++ b/custom_components/polestar_soc/translations/en.json
@@ -88,6 +88,9 @@
     "switch": {
       "charging_timer": {
         "name": "Charging timer"
+      },
+      "climate": {
+        "name": "Climate"
       }
     },
     "device_tracker": {

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -1,17 +1,25 @@
 """Tests for PCCS protobuf wire-format helpers."""
 
+import struct
+
 import pytest
 
 from custom_components.polestar_soc.pccs import (
+    _METHOD_CLIMATIZATION_START,
+    _METHOD_CLIMATIZATION_STOP,
     _METHOD_GET_CHARGE_TIMER,
     _METHOD_GET_TARGET_SOC,
     _METHOD_SET_CHARGE_TIMER,
     _METHOD_SET_TARGET_SOC,
     PccsClient,
+    _build_climatization_start_request,
+    _build_climatization_stop_request,
+    _build_invocation_request,
     _build_set_charge_timer_request,
     _build_set_target_soc_request,
     _build_time_of_day,
     _parse_charge_timer_response,
+    _parse_invocation_response,
     _parse_set_charge_timer_response,
     _parse_target_soc_response,
 )
@@ -19,6 +27,7 @@ from custom_components.polestar_soc.proto import (
     _decode_message,
     _decode_varint,
     _encode_field_bytes,
+    _encode_field_fixed32,
     _encode_field_varint,
     _encode_varint,
     _get_bool,
@@ -45,6 +54,14 @@ class TestServicePaths:
     def test_charge_timer_set_path(self):
         expected = "/pccs.chronos.services.v2.GlobalChargeTimerService/SetGlobalChargeTimer"
         assert expected == _METHOD_SET_CHARGE_TIMER
+
+    def test_climatization_start_path(self):
+        expected = "/pccs.invocation.v1.InvocationService/ClimatizationStart"
+        assert expected == _METHOD_CLIMATIZATION_START
+
+    def test_climatization_stop_path(self):
+        expected = "/pccs.invocation.v1.InvocationService/ClimatizationStop"
+        assert expected == _METHOD_CLIMATIZATION_STOP
 
 
 # ---------------------------------------------------------------------------
@@ -130,6 +147,30 @@ class TestEncodeFieldBytes:
         result = _encode_field_bytes(1, payload)
         decoded = _decode_message(result)
         assert decoded[1] == [b"hello"]
+
+
+class TestEncodeFieldFixed32:
+    def test_roundtrip(self):
+        result = _encode_field_fixed32(3, 22.0)
+        decoded = _decode_message(result)
+        assert 3 in decoded
+        # _decode_message stores fixed32 as uint32; reinterpret as float
+        raw = decoded[3][0]
+        value = struct.unpack("<f", struct.pack("<I", raw))[0]
+        assert value == pytest.approx(22.0)
+
+    def test_field_number_preserved(self):
+        for fn in (1, 3, 5):
+            result = _encode_field_fixed32(fn, 18.5)
+            decoded = _decode_message(result)
+            assert fn in decoded
+
+    def test_negative_temperature(self):
+        result = _encode_field_fixed32(3, -5.0)
+        decoded = _decode_message(result)
+        raw = decoded[3][0]
+        value = struct.unpack("<f", struct.pack("<I", raw))[0]
+        assert value == pytest.approx(-5.0)
 
 
 # ---------------------------------------------------------------------------
@@ -471,3 +512,126 @@ class TestPccsClientWriteToken:
         client = PccsClient("read-token", write_access_token="")
         meta = client._write_metadata("TESTVIN")
         assert ("authorization", "Bearer read-token") in meta
+
+
+# ---------------------------------------------------------------------------
+# Invocation message builders
+# ---------------------------------------------------------------------------
+
+
+class TestBuildInvocationRequest:
+    def test_field_layout(self):
+        data = _build_invocation_request("TESTVIN123")
+        fields = _decode_message(data)
+        # Field 1: UUID string
+        assert 1 in fields
+        uuid_val = fields[1][0]
+        assert isinstance(uuid_val, bytes)
+        assert len(uuid_val.decode("utf-8")) == 36  # UUID format
+        # Field 2: VIN string
+        assert fields[2] == [b"TESTVIN123"]
+        # Field 3: expiration timestamp (varint, should be > 0)
+        assert 3 in fields
+        assert fields[3][0] > 0
+
+
+class TestBuildClimatizationStartRequest:
+    def test_roundtrip(self):
+        data = _build_climatization_start_request("TESTVIN123", 22.0)
+        fields = _decode_message(data)
+        # Field 1: InvocationRequest sub-message
+        assert 1 in fields
+        invocation = _decode_message(fields[1][0])
+        assert invocation[2] == [b"TESTVIN123"]
+        # Field 2: start = true (varint 1)
+        assert fields[2] == [1]
+        # Field 3: temperature as fixed32
+        assert 3 in fields
+        raw = fields[3][0]
+        temp = struct.unpack("<f", struct.pack("<I", raw))[0]
+        assert temp == pytest.approx(22.0)
+
+    def test_default_temperature(self):
+        data = _build_climatization_start_request("TESTVIN123")
+        fields = _decode_message(data)
+        raw = fields[3][0]
+        temp = struct.unpack("<f", struct.pack("<I", raw))[0]
+        assert temp == pytest.approx(22.0)
+
+    def test_custom_temperature(self):
+        data = _build_climatization_start_request("TESTVIN123", 25.5)
+        fields = _decode_message(data)
+        raw = fields[3][0]
+        temp = struct.unpack("<f", struct.pack("<I", raw))[0]
+        assert temp == pytest.approx(25.5)
+
+
+class TestBuildClimatizationStopRequest:
+    def test_roundtrip(self):
+        data = _build_climatization_stop_request("TESTVIN123")
+        fields = _decode_message(data)
+        # Field 1: InvocationRequest sub-message (only field)
+        assert 1 in fields
+        invocation = _decode_message(fields[1][0])
+        assert invocation[2] == [b"TESTVIN123"]
+        # No other fields
+        assert 2 not in fields
+        assert 3 not in fields
+
+
+# ---------------------------------------------------------------------------
+# Invocation response parser
+# ---------------------------------------------------------------------------
+
+
+class TestParseInvocationResponse:
+    def test_empty_data(self):
+        result = _parse_invocation_response(b"")
+        assert result["id"] == ""
+        assert result["vin"] == ""
+        assert result["status"] == 0
+        assert result["message"] == ""
+
+    def test_success_status(self):
+        # Build InvocationResponse: id=1, vin=2, status=3, message=4
+        inner = (
+            _encode_field_bytes(1, b"test-uuid")
+            + _encode_field_bytes(2, b"TESTVIN123")
+            + _encode_field_varint(3, 6)  # SUCCESS
+        )
+        # Wrap in ClimatizationResponse: field 1 = InvocationResponse
+        data = _encode_field_bytes(1, inner)
+        result = _parse_invocation_response(data)
+        assert result["id"] == "test-uuid"
+        assert result["vin"] == "TESTVIN123"
+        assert result["status"] == 6
+        assert result["message"] == ""
+
+    def test_error_status_with_message(self):
+        inner = (
+            _encode_field_bytes(1, b"test-uuid")
+            + _encode_field_bytes(2, b"TESTVIN123")
+            + _encode_field_varint(3, 2)  # CAR_OFFLINE
+            + _encode_field_bytes(4, b"Vehicle not reachable")
+        )
+        data = _encode_field_bytes(1, inner)
+        result = _parse_invocation_response(data)
+        assert result["status"] == 2
+        assert result["message"] == "Vehicle not reachable"
+
+    def test_sent_status(self):
+        inner = (
+            _encode_field_bytes(1, b"test-uuid")
+            + _encode_field_bytes(2, b"TESTVIN123")
+            + _encode_field_varint(3, 1)  # SENT
+        )
+        data = _encode_field_bytes(1, inner)
+        result = _parse_invocation_response(data)
+        assert result["status"] == 1
+
+    def test_no_inner_message(self):
+        # Outer message with no field 1
+        data = _encode_field_varint(2, 42)
+        result = _parse_invocation_response(data)
+        assert result["id"] == ""
+        assert result["status"] == 0

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -217,9 +217,7 @@ class TestClimateEntity:
 
 class TestClimateTurnOn:
     @pytest.mark.asyncio
-    async def test_calls_climatization_start(
-        self, sample_coordinator_data, sample_vehicle
-    ):
+    async def test_calls_climatization_start(self, sample_coordinator_data, sample_vehicle):
         switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
 
         hass = MagicMock()
@@ -232,9 +230,7 @@ class TestClimateTurnOn:
         switch.coordinator.async_request_refresh.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_grpc_error_raises_ha_error(
-        self, sample_coordinator_data, sample_vehicle
-    ):
+    async def test_grpc_error_raises_ha_error(self, sample_coordinator_data, sample_vehicle):
         switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
 
         hass = MagicMock()
@@ -245,9 +241,7 @@ class TestClimateTurnOn:
             await switch.async_turn_on()
 
     @pytest.mark.asyncio
-    async def test_pccs_error_raises_ha_error(
-        self, sample_coordinator_data, sample_vehicle
-    ):
+    async def test_pccs_error_raises_ha_error(self, sample_coordinator_data, sample_vehicle):
         switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
 
         hass = MagicMock()
@@ -262,9 +256,7 @@ class TestClimateTurnOn:
 
 class TestClimateTurnOff:
     @pytest.mark.asyncio
-    async def test_calls_climatization_stop(
-        self, sample_coordinator_data, sample_vehicle
-    ):
+    async def test_calls_climatization_stop(self, sample_coordinator_data, sample_vehicle):
         switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
 
         hass = MagicMock()
@@ -277,9 +269,7 @@ class TestClimateTurnOff:
         switch.coordinator.async_request_refresh.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_grpc_error_raises_ha_error(
-        self, sample_coordinator_data, sample_vehicle
-    ):
+    async def test_grpc_error_raises_ha_error(self, sample_coordinator_data, sample_vehicle):
         switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
 
         hass = MagicMock()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -8,7 +8,7 @@ from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.polestar_soc.const import DOMAIN
 from custom_components.polestar_soc.pccs import PccsError
-from custom_components.polestar_soc.switch import PolestarChargeTimerSwitch
+from custom_components.polestar_soc.switch import PolestarChargeTimerSwitch, PolestarClimateSwitch
 
 VIN = "YSMYKEAE1RB000001"
 
@@ -145,3 +145,146 @@ class TestMissingTimerData:
         switch.coordinator.pccs.set_global_charge_timer.assert_called_once_with(
             VIN, 0, 0, 0, 0, True
         )
+
+
+# ===========================================================================
+# PolestarClimateSwitch tests
+# ===========================================================================
+
+
+def _make_climate_switch(
+    coordinator_data: dict | None,
+    vehicle: dict,
+    vin: str = VIN,
+) -> PolestarClimateSwitch:
+    """Create a PolestarClimateSwitch with a mock coordinator."""
+    coordinator = MagicMock()
+    coordinator.data = coordinator_data
+    coordinator.async_request_refresh = AsyncMock()
+    return PolestarClimateSwitch(coordinator, vehicle, vin)
+
+
+class TestClimateIsOn:
+    def test_active_preconditioning(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["climate"][VIN]["status"] = "Pre-conditioning"
+        switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.is_on is True
+
+    def test_active_starting(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["climate"][VIN]["status"] = "Starting"
+        switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.is_on is True
+
+    def test_off(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["climate"][VIN]["status"] = "Off"
+        switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.is_on is False
+
+    def test_unknown(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["climate"][VIN]["status"] = "Unknown"
+        switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.is_on is False
+
+    def test_none_when_no_coordinator_data(self, sample_vehicle):
+        switch = _make_climate_switch(None, sample_vehicle)
+        assert switch.is_on is None
+
+    def test_none_when_no_climate_data(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["climate"] = {}
+        switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.is_on is None
+
+    def test_none_when_status_is_none(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["climate"][VIN]["status"] = None
+        switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.is_on is None
+
+
+class TestClimateEntity:
+    def test_unique_id(self, sample_coordinator_data, sample_vehicle):
+        switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.unique_id == f"{VIN}_climate"
+
+    def test_translation_key(self, sample_coordinator_data, sample_vehicle):
+        switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.translation_key == "climate"
+
+    def test_device_info(self, sample_coordinator_data, sample_vehicle):
+        switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
+        assert switch.device_info["identifiers"] == {(DOMAIN, VIN)}
+        assert switch.device_info["manufacturer"] == "Polestar"
+
+
+class TestClimateTurnOn:
+    @pytest.mark.asyncio
+    async def test_calls_climatization_start(
+        self, sample_coordinator_data, sample_vehicle
+    ):
+        switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *args: fn(*args))
+        switch.hass = hass
+
+        await switch.async_turn_on()
+
+        switch.coordinator.pccs.climatization_start.assert_called_once_with(VIN)
+        switch.coordinator.async_request_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_grpc_error_raises_ha_error(
+        self, sample_coordinator_data, sample_vehicle
+    ):
+        switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=grpc.RpcError())
+        switch.hass = hass
+
+        with pytest.raises(HomeAssistantError, match="Failed to start climate"):
+            await switch.async_turn_on()
+
+    @pytest.mark.asyncio
+    async def test_pccs_error_raises_ha_error(
+        self, sample_coordinator_data, sample_vehicle
+    ):
+        switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(
+            side_effect=PccsError("Climatization command failed: CAR_OFFLINE")
+        )
+        switch.hass = hass
+
+        with pytest.raises(HomeAssistantError, match="Failed to start climate"):
+            await switch.async_turn_on()
+
+
+class TestClimateTurnOff:
+    @pytest.mark.asyncio
+    async def test_calls_climatization_stop(
+        self, sample_coordinator_data, sample_vehicle
+    ):
+        switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *args: fn(*args))
+        switch.hass = hass
+
+        await switch.async_turn_off()
+
+        switch.coordinator.pccs.climatization_stop.assert_called_once_with(VIN)
+        switch.coordinator.async_request_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_grpc_error_raises_ha_error(
+        self, sample_coordinator_data, sample_vehicle
+    ):
+        switch = _make_climate_switch(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=grpc.RpcError())
+        switch.hass = hass
+
+        with pytest.raises(HomeAssistantError, match="Failed to stop climate"):
+            await switch.async_turn_off()


### PR DESCRIPTION
## Summary
- Adds a **Climate** switch entity that starts/stops vehicle cabin pre-conditioning via the PCCS InvocationService gRPC API
- Turning on sends `ClimatizationStart` (22°C default temperature), turning off sends `ClimatizationStop`
- Switch state reflects the current climate status already polled via CEP (on when status is "Starting", "Pre-conditioning", etc.)
- Requires 2FA token (same as charge timer and charge limit writes)

## Changes
- **proto.py**: Add `_encode_field_fixed32()` for float encoding (temperature field)
- **pccs.py**: Add InvocationService support — request builders, response parser, and `PccsClient.climatization_start/stop()` with server-streaming response handling
- **switch.py**: Add `PolestarClimateSwitch` entity alongside existing charge timer switch
- **const.py**: Add `INVOCATION_STATUS_MAP` for InvocationResponse status codes
- **strings.json / en.json**: Add "Climate" switch translation
- **tests**: 27 new tests covering builders, parsers, and switch entity (222 total)

## Test plan
- [x] All 222 unit tests pass
- [x] Verified against live API: ClimatizationStart and ClimatizationStop both complete successfully (SENT → DELIVERED → SUCCESS)
- [x] Ruff linting passes
- [ ] Manual test in Home Assistant with 2FA configured