### PR TITLE
Add lock/unlock entity with door lock control

### DIFF
--- a/custom_components/polestar_soc/__init__.py
+++ b/custom_components/polestar_soc/__init__.py
@@ -14,6 +14,7 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.TIME,
     Platform.SWITCH,
+    Platform.LOCK,
     Platform.DEVICE_TRACKER,
     Platform.BINARY_SENSOR,
 ]

--- a/custom_components/polestar_soc/binary_sensor.py
+++ b/custom_components/polestar_soc/binary_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ALARM_STATUS_MAP, DOMAIN, LOCK_STATUS_MAP, OPEN_STATUS_MAP
+from .const import ALARM_STATUS_MAP, DOMAIN, OPEN_STATUS_MAP
 from .coordinator import PolestarCoordinator
 
 
@@ -30,17 +30,6 @@ class PolestarBinarySensorDescription(BinarySensorEntityDescription):
 # ---------------------------------------------------------------------------
 # is_on helpers
 # ---------------------------------------------------------------------------
-
-
-def _lock_is_on(data: dict, vin: str) -> bool | None:
-    """Central lock: True=Unlocked, False=Locked, None=Unknown."""
-    exterior = data.get("exterior", {}).get(vin)
-    if exterior is None:
-        return None
-    val = exterior.get("central_lock")
-    if val is None or val == 0:
-        return None
-    return val != 2  # anything other than LOCKED(2) is "on"
 
 
 def _open_status_is_on(key: str) -> Callable[[dict, str], bool | None]:
@@ -74,12 +63,6 @@ def _alarm_is_on(data: dict, vin: str) -> bool | None:
 # ---------------------------------------------------------------------------
 
 BINARY_SENSOR_DESCRIPTIONS: tuple[PolestarBinarySensorDescription, ...] = (
-    PolestarBinarySensorDescription(
-        key="central_lock",
-        translation_key="central_lock",
-        device_class=BinarySensorDeviceClass.LOCK,
-        is_on_fn=_lock_is_on,
-    ),
     PolestarBinarySensorDescription(
         key="front_left_door",
         translation_key="front_left_door",
@@ -172,7 +155,6 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PolestarBinarySensorDescription, ...] = (
 
 # Mapping from description key to the appropriate status map for raw_state labels
 _STATUS_MAP_BY_KEY: dict[str, dict[int, str | None]] = {
-    "central_lock": LOCK_STATUS_MAP,
     "alarm": ALARM_STATUS_MAP,
 }
 

--- a/custom_components/polestar_soc/const.py
+++ b/custom_components/polestar_soc/const.py
@@ -111,12 +111,6 @@ INVOCATION_STATUS_MAP: dict[int, str] = {
 _INVOCATION_INTERMEDIATE_STATUSES = {1, 4}  # SENT, DELIVERED
 
 # Exterior state enums (ExteriorService)
-LOCK_STATUS_MAP: dict[int, str | None] = {
-    0: None,
-    1: "Unlocked",
-    2: "Locked",
-}
-
 OPEN_STATUS_MAP: dict[int, str | None] = {
     0: None,
     1: "Open",

--- a/custom_components/polestar_soc/lock.py
+++ b/custom_components/polestar_soc/lock.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import grpc
@@ -17,8 +16,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import PolestarCoordinator
 from .pccs import PccsError
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(

--- a/custom_components/polestar_soc/lock.py
+++ b/custom_components/polestar_soc/lock.py
@@ -1,0 +1,106 @@
+"""Lock platform for Polestar — vehicle door lock control."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import grpc
+from homeassistant.components.lock import LockEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import PolestarCoordinator
+from .pccs import PccsError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Polestar lock entities from a config entry."""
+    coordinator: PolestarCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities: list[LockEntity] = []
+    for vehicle in coordinator.data.get("vehicles", []):
+        vin = vehicle["vin"]
+        entities.append(PolestarLock(coordinator, vehicle, vin))
+
+    async_add_entities(entities)
+
+
+class PolestarLock(CoordinatorEntity[PolestarCoordinator], LockEntity):
+    """Door lock — shows lock state and provides lock/unlock control."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "door_lock"
+
+    def __init__(
+        self,
+        coordinator: PolestarCoordinator,
+        vehicle: dict,
+        vin: str,
+    ) -> None:
+        """Initialize the lock entity."""
+        super().__init__(coordinator)
+        self._vin = vin
+        self._attr_unique_id = f"{vin}_lock"
+
+        model_name = "Polestar"
+        content = vehicle.get("content")
+        if content and content.get("model"):
+            model_name = content["model"].get("name", model_name)
+        year = vehicle.get("modelYear", "")
+        device_name = f"{model_name} ({year})" if year else model_name
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vin)},
+            name=device_name,
+            manufacturer="Polestar",
+            model=model_name,
+            sw_version=str(year) if year else None,
+        )
+
+    @property
+    def is_locked(self) -> bool | None:
+        """Return true if the vehicle is locked."""
+        data = self.coordinator.data
+        if not data:
+            return None
+        exterior = data.get("exterior", {}).get(self._vin)
+        if exterior is None:
+            return None
+        val = exterior.get("central_lock")
+        if val is None or val == 0:
+            return None
+        return val == 2  # LOCKED
+
+    async def async_lock(self, **kwargs: Any) -> None:
+        """Lock the vehicle."""
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.pccs.lock,
+                self._vin,
+            )
+        except (grpc.RpcError, PccsError) as err:
+            raise HomeAssistantError(f"Failed to lock: {err}") from err
+        await self.coordinator.async_request_refresh()
+
+    async def async_unlock(self, **kwargs: Any) -> None:
+        """Unlock the vehicle."""
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.pccs.unlock,
+                self._vin,
+            )
+        except (grpc.RpcError, PccsError) as err:
+            raise HomeAssistantError(f"Failed to unlock: {err}") from err
+        await self.coordinator.async_request_refresh()

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -13,6 +13,7 @@ import datetime
 import logging
 import time
 import uuid
+from collections.abc import Callable
 
 import grpc
 from homeassistant.exceptions import HomeAssistantError
@@ -56,6 +57,8 @@ _METHOD_GET_CHARGE_TIMER = f"{_SVC_CHARGE_TIMER}/GetGlobalChargeTimerStream"
 _METHOD_SET_CHARGE_TIMER = f"{_SVC_CHARGE_TIMER}/SetGlobalChargeTimer"
 _METHOD_CLIMATIZATION_START = f"{_SVC_INVOCATION}/ClimatizationStart"
 _METHOD_CLIMATIZATION_STOP = f"{_SVC_INVOCATION}/ClimatizationStop"
+_METHOD_LOCK = f"{_SVC_INVOCATION}/Lock"
+_METHOD_UNLOCK = f"{_SVC_INVOCATION}/Unlock"
 
 _INVOCATION_EXPIRY_MS = 120_000  # command expiry: 120 seconds
 
@@ -181,6 +184,46 @@ def _build_climatization_start_request(vin: str, temperature: float = 22.0) -> b
 def _build_climatization_stop_request(vin: str) -> bytes:
     """Build ClimatizationStopRequest bytes."""
     return _encode_field_bytes(1, _build_invocation_request(vin))
+
+
+def _build_lock_request(vin: str, lock_type: int = 0) -> bytes:
+    """Build LockRequest bytes.
+
+    LockRequest:
+        field 1: InvocationRequest (message)
+        field 2: lockType (LockType enum: 0=LOCK, 1=LOCK_REDUCED_GUARD)
+    """
+    msg = _encode_field_bytes(1, _build_invocation_request(vin))
+    if lock_type:
+        msg += _encode_field_varint(2, lock_type)
+    return msg
+
+
+def _build_unlock_request(vin: str) -> bytes:
+    """Build UnlockRequest bytes.
+
+    Structurally identical to ClimatizationStopRequest —
+    InvocationRequest in field 1, no additional fields.
+    """
+    return _encode_field_bytes(1, _build_invocation_request(vin))
+
+
+def _lock_error_context(data: bytes) -> str:
+    """Extract lock-specific error context from a LockResponse.
+
+    LockResponse field 2 is lockError (LockError enum):
+        0 = LOCK_ERROR_UNSPECIFIED
+        1 = LOCK_ERROR_DOOR_OPEN
+    """
+    if not data:
+        return ""
+    outer = _decode_message(data)
+    lock_error = _get_int(outer, 2, 0)
+    if lock_error == 1:
+        return "a door is open"
+    if lock_error > 1:
+        return f"lock error (code {lock_error})"
+    return ""
 
 
 def _parse_invocation_response(data: bytes) -> dict:
@@ -531,7 +574,15 @@ class PccsClient:
 
     # -- Climate (InvocationService) -----------------------------------------
 
-    def _send_invocation(self, vin: str, method_path: str, request: bytes) -> dict:
+    def _send_invocation(
+        self,
+        vin: str,
+        method_path: str,
+        request: bytes,
+        *,
+        command_name: str = "Command",
+        error_context_fn: Callable[[bytes], str] | None = None,
+    ) -> dict:
         """Send an InvocationService command and wait for terminal status.
 
         InvocationService methods are SERVER_STREAMING.  The stream emits
@@ -541,6 +592,11 @@ class PccsClient:
         The server may cancel the stream (~5s timeout) before SUCCESS
         arrives.  If we received DELIVERED before cancellation, the command
         was accepted by the vehicle and we treat it as success.
+
+        Args:
+            command_name: Human-readable name for error messages.
+            error_context_fn: Optional callback that receives the raw terminal
+                response bytes and returns additional error context text.
         """
         channel = self._get_channel()
         method = channel.unary_stream(
@@ -549,9 +605,11 @@ class PccsClient:
             response_deserializer=_identity_deserialize,
         )
         result = _parse_invocation_response(b"")
+        last_raw = b""
         try:
             responses = method(request, metadata=self._write_metadata(vin), timeout=60)
             for response in responses:
+                last_raw = response
                 result = _parse_invocation_response(response)
                 status = result.get("status", 0)
                 if status not in _INVOCATION_INTERMEDIATE_STATUSES:
@@ -572,9 +630,13 @@ class PccsClient:
         if status not in (4, 6):  # Not DELIVERED or SUCCESS
             status_name = INVOCATION_STATUS_MAP.get(status, f"STATUS_{status}")
             server_msg = result.get("message", "")
-            msg = f"Climatization command failed: {status_name}"
+            msg = f"{command_name} failed: {status_name}"
             if server_msg:
                 msg += f" - {server_msg}"
+            if error_context_fn and last_raw:
+                ctx = error_context_fn(last_raw)
+                if ctx:
+                    msg += f" ({ctx})"
             raise PccsError(msg)
 
         return result
@@ -585,7 +647,9 @@ class PccsClient:
         Requires the PCCS 2FA token (customer:attributes:write scope).
         """
         request = _build_climatization_start_request(vin, temperature)
-        return self._send_invocation(vin, _METHOD_CLIMATIZATION_START, request)
+        return self._send_invocation(
+            vin, _METHOD_CLIMATIZATION_START, request, command_name="Climatization"
+        )
 
     def climatization_stop(self, vin: str) -> dict:
         """Stop vehicle climate pre-conditioning.
@@ -593,4 +657,35 @@ class PccsClient:
         Requires the PCCS 2FA token (customer:attributes:write scope).
         """
         request = _build_climatization_stop_request(vin)
-        return self._send_invocation(vin, _METHOD_CLIMATIZATION_STOP, request)
+        return self._send_invocation(
+            vin, _METHOD_CLIMATIZATION_STOP, request, command_name="Climatization"
+        )
+
+    # -- Lock/Unlock (InvocationService) ------------------------------------
+
+    def lock(self, vin: str, lock_type: int = 0) -> dict:
+        """Lock the vehicle.
+
+        Requires the PCCS 2FA token (customer:attributes:write scope).
+
+        Args:
+            lock_type: LockType enum (0=LOCK, 1=LOCK_REDUCED_GUARD).
+        """
+        request = _build_lock_request(vin, lock_type)
+        return self._send_invocation(
+            vin,
+            _METHOD_LOCK,
+            request,
+            command_name="Lock",
+            error_context_fn=_lock_error_context,
+        )
+
+    def unlock(self, vin: str) -> dict:
+        """Unlock the vehicle.
+
+        Requires the PCCS 2FA token (customer:attributes:write scope).
+        """
+        request = _build_unlock_request(vin)
+        return self._send_invocation(
+            vin, _METHOD_UNLOCK, request, command_name="Unlock"
+        )

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -686,6 +686,4 @@ class PccsClient:
         Requires the PCCS 2FA token (customer:attributes:write scope).
         """
         request = _build_unlock_request(vin)
-        return self._send_invocation(
-            vin, _METHOD_UNLOCK, request, command_name="Unlock"
-        )
+        return self._send_invocation(vin, _METHOD_UNLOCK, request, command_name="Unlock")

--- a/custom_components/polestar_soc/strings.json
+++ b/custom_components/polestar_soc/strings.json
@@ -93,15 +93,17 @@
         "name": "Climate"
       }
     },
+    "lock": {
+      "door_lock": {
+        "name": "Door lock"
+      }
+    },
     "device_tracker": {
       "location": {
         "name": "Location"
       }
     },
     "binary_sensor": {
-      "central_lock": {
-        "name": "Central lock"
-      },
       "front_left_door": {
         "name": "Front left door"
       },

--- a/custom_components/polestar_soc/translations/en.json
+++ b/custom_components/polestar_soc/translations/en.json
@@ -93,15 +93,17 @@
         "name": "Climate"
       }
     },
+    "lock": {
+      "door_lock": {
+        "name": "Door lock"
+      }
+    },
     "device_tracker": {
       "location": {
         "name": "Location"
       }
     },
     "binary_sensor": {
-      "central_lock": {
-        "name": "Central lock"
-      },
       "front_left_door": {
         "name": "Front left door"
       },

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -17,30 +17,13 @@ def _make_sensor(
     coordinator_data: dict | None,
     vehicle: dict,
     vin: str,
-    key: str = "central_lock",
+    key: str = "front_left_door",
 ) -> PolestarBinarySensor:
     """Create a PolestarBinarySensor with a mock coordinator."""
     coordinator = MagicMock()
     coordinator.data = coordinator_data
     desc = next(d for d in BINARY_SENSOR_DESCRIPTIONS if d.key == key)
     return PolestarBinarySensor(coordinator, desc, vehicle, vin)
-
-
-class TestLockIsOn:
-    def test_locked(self, sample_coordinator_data, sample_vehicle):
-        sample_coordinator_data["exterior"][VIN]["central_lock"] = 2  # LOCKED
-        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
-        assert sensor.is_on is False
-
-    def test_unlocked(self, sample_coordinator_data, sample_vehicle):
-        sample_coordinator_data["exterior"][VIN]["central_lock"] = 1  # UNLOCKED
-        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
-        assert sensor.is_on is True
-
-    def test_unspecified(self, sample_coordinator_data, sample_vehicle):
-        sample_coordinator_data["exterior"][VIN]["central_lock"] = 0  # UNSPECIFIED
-        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
-        assert sensor.is_on is None
 
 
 class TestDoorIsOn:
@@ -82,17 +65,13 @@ class TestAlarmIsOn:
 
 class TestBinarySensorEntity:
     def test_unique_id(self, sample_coordinator_data, sample_vehicle):
-        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
-        assert sensor.unique_id == f"{VIN}_central_lock"
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "front_left_door")
+        assert sensor.unique_id == f"{VIN}_front_left_door"
 
     def test_device_info(self, sample_coordinator_data, sample_vehicle):
-        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "front_left_door")
         assert sensor.device_info["identifiers"] == {(DOMAIN, VIN)}
         assert sensor.device_info["manufacturer"] == "Polestar"
-
-    def test_device_class_lock(self, sample_coordinator_data, sample_vehicle):
-        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
-        assert sensor.device_class == BinarySensorDeviceClass.LOCK
 
     def test_device_class_door(self, sample_coordinator_data, sample_vehicle):
         sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "front_left_door")
@@ -112,17 +91,6 @@ class TestBinarySensorEntity:
 
 
 class TestExtraStateAttributes:
-    def test_locked_label(self, sample_coordinator_data, sample_vehicle):
-        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
-        attrs = sensor.extra_state_attributes
-        assert attrs is not None
-        assert attrs["raw_state"] == "Locked"
-
-    def test_unlocked_label(self, sample_coordinator_data, sample_vehicle):
-        sample_coordinator_data["exterior"][VIN]["central_lock"] = 1
-        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
-        assert sensor.extra_state_attributes["raw_state"] == "Unlocked"
-
     def test_door_closed_label(self, sample_coordinator_data, sample_vehicle):
         sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "front_left_door")
         assert sensor.extra_state_attributes["raw_state"] == "Closed"
@@ -146,30 +114,30 @@ class TestExtraStateAttributes:
 
 class TestNoneHandling:
     def test_none_when_no_coordinator_data(self, sample_vehicle):
-        sensor = _make_sensor(None, sample_vehicle, VIN, "central_lock")
+        sensor = _make_sensor(None, sample_vehicle, VIN, "front_left_door")
         assert sensor.is_on is None
         assert sensor.extra_state_attributes is None
 
     def test_none_when_no_exterior_data(self, sample_coordinator_data, sample_vehicle):
         sample_coordinator_data["exterior"] = {}
-        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "front_left_door")
         assert sensor.is_on is None
         assert sensor.extra_state_attributes is None
 
     def test_none_when_field_is_none(self, sample_coordinator_data, sample_vehicle):
-        sample_coordinator_data["exterior"][VIN]["central_lock"] = None
-        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "central_lock")
+        sample_coordinator_data["exterior"][VIN]["front_left_door"] = None
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "front_left_door")
         assert sensor.is_on is None
         assert sensor.extra_state_attributes is None
 
 
 class TestDescriptionCounts:
     def test_total_descriptions(self):
-        assert len(BINARY_SENSOR_DESCRIPTIONS) == 14
+        assert len(BINARY_SENSOR_DESCRIPTIONS) == 13
 
     def test_enabled_by_default_count(self):
         enabled = [d for d in BINARY_SENSOR_DESCRIPTIONS if d.entity_registry_enabled_default]
-        assert len(enabled) == 5  # central_lock + 4 doors
+        assert len(enabled) == 4  # 4 doors
 
     def test_disabled_by_default_count(self):
         disabled = [d for d in BINARY_SENSOR_DESCRIPTIONS if not d.entity_registry_enabled_default]

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,0 +1,140 @@
+"""Tests for lock platform — vehicle door lock control."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import grpc
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.polestar_soc.const import DOMAIN
+from custom_components.polestar_soc.lock import PolestarLock
+from custom_components.polestar_soc.pccs import PccsError
+
+VIN = "YSMYKEAE1RB000001"
+
+
+def _make_lock(
+    coordinator_data: dict | None,
+    vehicle: dict,
+    vin: str = VIN,
+) -> PolestarLock:
+    """Create a PolestarLock with a mock coordinator."""
+    coordinator = MagicMock()
+    coordinator.data = coordinator_data
+    coordinator.async_request_refresh = AsyncMock()
+    return PolestarLock(coordinator, vehicle, vin)
+
+
+class TestIsLocked:
+    def test_locked(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["central_lock"] = 2  # LOCKED
+        lock = _make_lock(sample_coordinator_data, sample_vehicle)
+        assert lock.is_locked is True
+
+    def test_unlocked(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["central_lock"] = 1  # UNLOCKED
+        lock = _make_lock(sample_coordinator_data, sample_vehicle)
+        assert lock.is_locked is False
+
+    def test_unspecified(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["central_lock"] = 0  # UNSPECIFIED
+        lock = _make_lock(sample_coordinator_data, sample_vehicle)
+        assert lock.is_locked is None
+
+    def test_none_value(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"][VIN]["central_lock"] = None
+        lock = _make_lock(sample_coordinator_data, sample_vehicle)
+        assert lock.is_locked is None
+
+    def test_none_when_no_coordinator_data(self, sample_vehicle):
+        lock = _make_lock(None, sample_vehicle)
+        assert lock.is_locked is None
+
+    def test_none_when_no_exterior_data(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["exterior"] = {}
+        lock = _make_lock(sample_coordinator_data, sample_vehicle)
+        assert lock.is_locked is None
+
+
+class TestEntity:
+    def test_unique_id(self, sample_coordinator_data, sample_vehicle):
+        lock = _make_lock(sample_coordinator_data, sample_vehicle)
+        assert lock.unique_id == f"{VIN}_lock"
+
+    def test_translation_key(self, sample_coordinator_data, sample_vehicle):
+        lock = _make_lock(sample_coordinator_data, sample_vehicle)
+        assert lock.translation_key == "door_lock"
+
+    def test_has_entity_name(self, sample_coordinator_data, sample_vehicle):
+        lock = _make_lock(sample_coordinator_data, sample_vehicle)
+        assert lock.has_entity_name is True
+
+    def test_device_info(self, sample_coordinator_data, sample_vehicle):
+        lock = _make_lock(sample_coordinator_data, sample_vehicle)
+        assert lock.device_info["identifiers"] == {(DOMAIN, VIN)}
+        assert lock.device_info["manufacturer"] == "Polestar"
+
+
+class TestAsyncLock:
+    @pytest.mark.asyncio
+    async def test_calls_pccs_lock(self, sample_coordinator_data, sample_vehicle):
+        lock = _make_lock(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *args: fn(*args))
+        lock.hass = hass
+
+        await lock.async_lock()
+
+        lock.coordinator.pccs.lock.assert_called_once_with(VIN)
+        lock.coordinator.async_request_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_grpc_error_raises_ha_error(self, sample_coordinator_data, sample_vehicle):
+        lock = _make_lock(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=grpc.RpcError())
+        lock.hass = hass
+
+        with pytest.raises(HomeAssistantError, match="Failed to lock"):
+            await lock.async_lock()
+
+    @pytest.mark.asyncio
+    async def test_pccs_error_raises_ha_error(self, sample_coordinator_data, sample_vehicle):
+        lock = _make_lock(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(
+            side_effect=PccsError("Lock failed: INVOCATION_SPECIFIC_ERROR (a door is open)")
+        )
+        lock.hass = hass
+
+        with pytest.raises(HomeAssistantError, match="Failed to lock"):
+            await lock.async_lock()
+
+
+class TestAsyncUnlock:
+    @pytest.mark.asyncio
+    async def test_calls_pccs_unlock(self, sample_coordinator_data, sample_vehicle):
+        lock = _make_lock(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *args: fn(*args))
+        lock.hass = hass
+
+        await lock.async_unlock()
+
+        lock.coordinator.pccs.unlock.assert_called_once_with(VIN)
+        lock.coordinator.async_request_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_grpc_error_raises_ha_error(self, sample_coordinator_data, sample_vehicle):
+        lock = _make_lock(sample_coordinator_data, sample_vehicle)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=grpc.RpcError())
+        lock.hass = hass
+
+        with pytest.raises(HomeAssistantError, match="Failed to unlock"):
+            await lock.async_unlock()

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -9,15 +9,20 @@ from custom_components.polestar_soc.pccs import (
     _METHOD_CLIMATIZATION_STOP,
     _METHOD_GET_CHARGE_TIMER,
     _METHOD_GET_TARGET_SOC,
+    _METHOD_LOCK,
     _METHOD_SET_CHARGE_TIMER,
     _METHOD_SET_TARGET_SOC,
+    _METHOD_UNLOCK,
     PccsClient,
     _build_climatization_start_request,
     _build_climatization_stop_request,
     _build_invocation_request,
+    _build_lock_request,
     _build_set_charge_timer_request,
     _build_set_target_soc_request,
     _build_time_of_day,
+    _build_unlock_request,
+    _lock_error_context,
     _parse_charge_timer_response,
     _parse_invocation_response,
     _parse_set_charge_timer_response,
@@ -635,3 +640,107 @@ class TestParseInvocationResponse:
         result = _parse_invocation_response(data)
         assert result["id"] == ""
         assert result["status"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Lock/Unlock service paths
+# ---------------------------------------------------------------------------
+
+
+class TestLockServicePaths:
+    def test_lock_path(self):
+        assert _METHOD_LOCK == "/pccs.invocation.v1.InvocationService/Lock"
+
+    def test_unlock_path(self):
+        assert _METHOD_UNLOCK == "/pccs.invocation.v1.InvocationService/Unlock"
+
+
+# ---------------------------------------------------------------------------
+# Lock/Unlock message builders
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLockRequest:
+    def test_default_lock_type(self):
+        data = _build_lock_request("TESTVIN123")
+        fields = _decode_message(data)
+        # Field 1: InvocationRequest sub-message
+        assert 1 in fields
+        invocation = _decode_message(fields[1][0])
+        assert invocation[2] == [b"TESTVIN123"]
+        # Field 2: lockType omitted for default (0 = LOCK)
+        assert 2 not in fields
+
+    def test_reduced_guard_lock_type(self):
+        data = _build_lock_request("TESTVIN123", lock_type=1)
+        fields = _decode_message(data)
+        assert 1 in fields
+        # Field 2: lockType = 1 (LOCK_REDUCED_GUARD)
+        assert fields[2] == [1]
+
+    def test_invocation_request_has_uuid_and_expiry(self):
+        data = _build_lock_request("TESTVIN123")
+        fields = _decode_message(data)
+        invocation = _decode_message(fields[1][0])
+        # Field 1: UUID
+        uuid_val = invocation[1][0]
+        assert isinstance(uuid_val, bytes)
+        assert len(uuid_val.decode("utf-8")) == 36
+        # Field 3: expiration timestamp
+        assert invocation[3][0] > 0
+
+
+class TestBuildUnlockRequest:
+    def test_roundtrip(self):
+        data = _build_unlock_request("TESTVIN123")
+        fields = _decode_message(data)
+        # Field 1: InvocationRequest sub-message (only field)
+        assert 1 in fields
+        invocation = _decode_message(fields[1][0])
+        assert invocation[2] == [b"TESTVIN123"]
+        # No other fields
+        assert 2 not in fields
+        assert 3 not in fields
+
+    def test_structurally_identical_to_climatization_stop(self):
+        """UnlockRequest has the same wire structure as ClimatizationStopRequest."""
+        lock_data = _build_unlock_request("SAMEVIN")
+        stop_data = _build_climatization_stop_request("SAMEVIN")
+        # Both have only field 1, but UUIDs differ — check field layout
+        lock_fields = _decode_message(lock_data)
+        stop_fields = _decode_message(stop_data)
+        assert set(lock_fields.keys()) == set(stop_fields.keys()) == {1}
+
+
+# ---------------------------------------------------------------------------
+# Lock error context
+# ---------------------------------------------------------------------------
+
+
+class TestLockErrorContext:
+    def test_empty_data(self):
+        assert _lock_error_context(b"") == ""
+
+    def test_no_lock_error(self):
+        # Response with only InvocationResponse in field 1, no field 2
+        inner = _encode_field_varint(3, 6)  # status = SUCCESS
+        data = _encode_field_bytes(1, inner)
+        assert _lock_error_context(data) == ""
+
+    def test_door_open_error(self):
+        # LockResponse with lockError=1 (LOCK_ERROR_DOOR_OPEN) in field 2
+        inner = _encode_field_varint(3, 11)  # status = INVOCATION_SPECIFIC_ERROR
+        data = _encode_field_bytes(1, inner) + _encode_field_varint(2, 1)
+        assert _lock_error_context(data) == "a door is open"
+
+    def test_unspecified_error(self):
+        # lockError=0 (LOCK_ERROR_UNSPECIFIED) should return empty
+        inner = _encode_field_varint(3, 6)
+        data = _encode_field_bytes(1, inner) + _encode_field_varint(2, 0)
+        assert _lock_error_context(data) == ""
+
+    def test_unknown_error_code(self):
+        # Unknown lockError value should return generic message
+        inner = _encode_field_varint(3, 11)
+        data = _encode_field_bytes(1, inner) + _encode_field_varint(2, 99)
+        assert _lock_error_context(data) == "lock error (code 99)"


### PR DESCRIPTION
## Summary

- Replace the read-only `central_lock` binary sensor with a `LockEntity` that provides both state and lock/unlock control
- Add `lock()` and `unlock()` methods to `PccsClient` via the InvocationService (same pattern as climatization start/stop)
- Parameterize `_send_invocation()` error messages so each command type gets a descriptive error
- Surface lock-specific errors (e.g. "a door is open" when a door is open)

## Test plan
- [x] Unit tests for lock entity state (locked/unlocked/unspecified/none)
- [x] Unit tests for lock/unlock command calls and error handling
- [x] Unit tests for lock/unlock protobuf builders and service paths
- [x] Unit tests for lock error context extraction
- [x] Updated binary sensor tests (central_lock removed)
- [x] All 243 tests pass
- [x] Verified lock and unlock against live API — both commands succeed, exterior state updates correctly