### PR TITLE
Add window open/close cover entity

### DIFF
--- a/custom_components/polestar_soc/__init__.py
+++ b/custom_components/polestar_soc/__init__.py
@@ -15,6 +15,7 @@ PLATFORMS: list[Platform] = [
     Platform.TIME,
     Platform.SWITCH,
     Platform.LOCK,
+    Platform.COVER,
     Platform.DEVICE_TRACKER,
     Platform.BINARY_SENSOR,
 ]

--- a/custom_components/polestar_soc/cep.py
+++ b/custom_components/polestar_soc/cep.py
@@ -30,6 +30,7 @@ from .proto import (
     _get_submessage,
     _identity_deserialize,
     _identity_serialize,
+    _parse_invocation_response,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -89,48 +90,6 @@ def _build_window_control_request(vin: str, control_type: int) -> bytes:
     msg = _encode_field_bytes(1, _build_cep_invocation_request(vin))
     msg += _encode_field_varint(2, control_type)
     return msg
-
-
-def _parse_invocation_response(data: bytes) -> dict:
-    """Parse a CEP InvocationResponse from a command response.
-
-    Response wrapper (e.g. WindowControlResponse):
-        field 1: InvocationResponse (message)
-
-    InvocationResponse:
-        field 1: id (string)
-        field 2: vin (string)
-        field 3: status (varint enum)
-        field 4: message (string)
-        field 5: timestamp (int64)
-    """
-    empty = {"id": "", "vin": "", "status": 0, "message": ""}
-    if not data:
-        return empty
-
-    outer = _decode_message(data)
-    inner = _get_submessage(outer, 1)
-    if inner is None:
-        return empty
-
-    id_val = inner.get(1, [b""])[0]
-    if isinstance(id_val, bytes):
-        id_val = id_val.decode("utf-8", errors="replace")
-
-    vin_val = inner.get(2, [b""])[0]
-    if isinstance(vin_val, bytes):
-        vin_val = vin_val.decode("utf-8", errors="replace")
-
-    msg_val = inner.get(4, [b""])[0]
-    if isinstance(msg_val, bytes):
-        msg_val = msg_val.decode("utf-8", errors="replace")
-
-    return {
-        "id": id_val,
-        "vin": vin_val,
-        "status": _get_int(inner, 3, 0),
-        "message": msg_val,
-    }
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/polestar_soc/cep.py
+++ b/custom_components/polestar_soc/cep.py
@@ -1,9 +1,10 @@
 """CEP (Volvo Connected Experience Platform) gRPC client.
 
 Communicates with the Volvo CEP gRPC API at cepmobtoken.eu.prod.c3.volvocars.com
-for reading vehicle state data (climate status, battery, etc.).
+for reading vehicle state data (climate status, battery, etc.) and sending
+vehicle commands (window control) via the InvocationService.
 
-Uses the same Polestar OAuth access token as the rest of the integration.
+Uses the web OAuth access token for reads and the PCCS 2FA token for writes.
 """
 
 from __future__ import annotations
@@ -11,15 +12,19 @@ from __future__ import annotations
 import logging
 
 import grpc
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import (
+    _INVOCATION_INTERMEDIATE_STATUSES,
     CEP_API_HOST,
     CLIMATE_RUNNING_STATUS_MAP,
     HEATING_INTENSITY_MAP,
+    INVOCATION_STATUS_MAP,
 )
 from .proto import (
     _decode_message,
     _encode_field_bytes,
+    _encode_field_varint,
     _get_double,
     _get_int,
     _get_submessage,
@@ -37,6 +42,8 @@ _METHOD_GET_CLIMATE = (
 _METHOD_GET_BATTERY = "/services.vehiclestates.battery.BatteryService/GetLatestBattery"
 _METHOD_GET_EXTERIOR = "/services.vehiclestates.exterior.ExteriorService/GetLatestExterior"
 _METHOD_GET_LOCATION = "/dtlinternet.DtlInternetService/GetLastKnownLocation"
+_SVC_INVOCATION = "/invocation.InvocationService"
+_METHOD_WINDOW_CONTROL = f"{_SVC_INVOCATION}/WindowControl"
 
 # BatteryState field numbers captured in raw_fields for debugging.
 _RAW_BATTERY_FIELD_NUMBERS = (5, 7, 8, 17, 26, 28)
@@ -55,6 +62,75 @@ def _build_vin_request(vin: str) -> bytes:
 def _build_location_request(vin: str) -> bytes:
     """Build a request with VIN as field 1 (DtlInternetService uses field 1, not field 2)."""
     return _encode_field_bytes(1, vin.encode("utf-8"))
+
+
+def _build_cep_invocation_request(vin: str) -> bytes:
+    """Build a CEP InvocationRequest sub-message.
+
+    CEP InvocationRequest (invocation.InvocationRequest):
+        field 1: vin (string)
+
+    This is simpler than the PCCS InvocationRequest which also has
+    id (UUID) and expirationTimestamp fields.
+    """
+    return _encode_field_bytes(1, vin.encode("utf-8"))
+
+
+def _build_window_control_request(vin: str, control_type: int) -> bytes:
+    """Build WindowControlRequest bytes for CEP.
+
+    WindowControlRequest:
+        field 1: InvocationRequest (message) — CEP format (VIN only)
+        field 2: windowsControl (WindowControlType enum)
+            0 = WINDOW_CONTROL_TYPE_UNSPECIFIED
+            1 = OPEN_ALL
+            2 = CLOSE_ALL
+    """
+    msg = _encode_field_bytes(1, _build_cep_invocation_request(vin))
+    msg += _encode_field_varint(2, control_type)
+    return msg
+
+
+def _parse_invocation_response(data: bytes) -> dict:
+    """Parse a CEP InvocationResponse from a command response.
+
+    Response wrapper (e.g. WindowControlResponse):
+        field 1: InvocationResponse (message)
+
+    InvocationResponse:
+        field 1: id (string)
+        field 2: vin (string)
+        field 3: status (varint enum)
+        field 4: message (string)
+        field 5: timestamp (int64)
+    """
+    empty = {"id": "", "vin": "", "status": 0, "message": ""}
+    if not data:
+        return empty
+
+    outer = _decode_message(data)
+    inner = _get_submessage(outer, 1)
+    if inner is None:
+        return empty
+
+    id_val = inner.get(1, [b""])[0]
+    if isinstance(id_val, bytes):
+        id_val = id_val.decode("utf-8", errors="replace")
+
+    vin_val = inner.get(2, [b""])[0]
+    if isinstance(vin_val, bytes):
+        vin_val = vin_val.decode("utf-8", errors="replace")
+
+    msg_val = inner.get(4, [b""])[0]
+    if isinstance(msg_val, bytes):
+        msg_val = msg_val.decode("utf-8", errors="replace")
+
+    return {
+        "id": id_val,
+        "vin": vin_val,
+        "status": _get_int(inner, 3, 0),
+        "message": msg_val,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -240,11 +316,20 @@ def _parse_location_response(data: bytes) -> dict:
 # ---------------------------------------------------------------------------
 
 
-class CepClient:
-    """Client for the Volvo CEP gRPC API."""
+class CepError(HomeAssistantError):
+    """Error returned by a CEP InvocationService command."""
 
-    def __init__(self, access_token: str) -> None:
+
+class CepClient:
+    """Client for the Volvo CEP gRPC API.
+
+    Uses ``access_token`` for read operations (web client token) and
+    ``write_access_token`` for command operations (PCCS 2FA token).
+    """
+
+    def __init__(self, access_token: str, write_access_token: str | None = None) -> None:
         self._access_token = access_token
+        self._write_access_token = write_access_token
         self._channel: grpc.Channel | None = None
 
     @property
@@ -255,6 +340,14 @@ class CepClient:
     def access_token(self, value: str) -> None:
         self._access_token = value
 
+    @property
+    def write_access_token(self) -> str | None:
+        return self._write_access_token
+
+    @write_access_token.setter
+    def write_access_token(self, value: str | None) -> None:
+        self._write_access_token = value
+
     def _get_channel(self) -> grpc.Channel:
         if self._channel is None:
             credentials = grpc.ssl_channel_credentials()
@@ -264,6 +357,20 @@ class CepClient:
     def _metadata(self, vin: str) -> list[tuple[str, str]]:
         return [
             ("authorization", f"Bearer {self._access_token}"),
+            ("vin", vin),
+        ]
+
+    def _write_metadata(self, vin: str) -> list[tuple[str, str]]:
+        """Build gRPC call metadata for write/command operations.
+
+        Uses the write token (PCCS 2FA) when available, otherwise falls
+        back to the regular read token.
+        """
+        token = self._write_access_token or self._access_token
+        if not self._write_access_token:
+            _LOGGER.debug("No CEP write token available, falling back to web token")
+        return [
+            ("authorization", f"Bearer {token}"),
             ("vin", vin),
         ]
 
@@ -333,3 +440,79 @@ class CepClient:
         except grpc.RpcError as err:
             _LOGGER.warning("CEP GetLastKnownLocation failed: %s", err)
             raise
+
+    # -- Window Control (InvocationService) ---------------------------------
+
+    def _send_invocation(
+        self,
+        vin: str,
+        method_path: str,
+        request: bytes,
+        *,
+        command_name: str = "Command",
+    ) -> dict:
+        """Send a CEP InvocationService command and wait for terminal status.
+
+        CEP InvocationService methods are SERVER_STREAMING. The stream emits
+        intermediate statuses (SENT, DELIVERED) before a terminal status
+        (SUCCESS or an error). We iterate until we reach a terminal status.
+
+        The server may cancel the stream before SUCCESS arrives. If we
+        received DELIVERED before cancellation, we treat it as success.
+        """
+        channel = self._get_channel()
+        method = channel.unary_stream(
+            method_path,
+            request_serializer=_identity_serialize,
+            response_deserializer=_identity_deserialize,
+        )
+        result = _parse_invocation_response(b"")
+        try:
+            responses = method(request, metadata=self._write_metadata(vin), timeout=60)
+            for response in responses:
+                result = _parse_invocation_response(response)
+                status = result.get("status", 0)
+                if status not in _INVOCATION_INTERMEDIATE_STATUSES:
+                    break
+        except grpc.RpcError as err:
+            if result.get("status") == 4:  # DELIVERED
+                _LOGGER.debug(
+                    "CEP %s stream cancelled after DELIVERED — treating as success",
+                    method_path,
+                )
+                return result
+            _LOGGER.warning("CEP %s failed: %s", method_path, err)
+            raise
+
+        status = result.get("status", 0)
+        if status not in (4, 6):  # Not DELIVERED or SUCCESS
+            status_name = INVOCATION_STATUS_MAP.get(status, f"STATUS_{status}")
+            server_msg = result.get("message", "")
+            msg = f"{command_name} failed: {status_name}"
+            if server_msg:
+                msg += f" - {server_msg}"
+            raise CepError(msg)
+
+        return result
+
+    def window_open(self, vin: str) -> dict:
+        """Open all vehicle windows.
+
+        Requires the PCCS 2FA token (customer:attributes:write scope).
+        WindowControl is only available on CEP, not PCCS.
+        """
+        request = _build_window_control_request(vin, 1)  # OPEN_ALL
+        return self._send_invocation(
+            vin, _METHOD_WINDOW_CONTROL, request, command_name="Window control"
+        )
+
+    def window_close(self, vin: str) -> dict:
+        """Close all vehicle windows.
+
+        Requires the PCCS 2FA token (customer:attributes:write scope).
+        WindowControl is only available on CEP, not PCCS.
+        """
+        request = _build_window_control_request(vin, 2)  # CLOSE_ALL
+        return self._send_invocation(
+            vin, _METHOD_WINDOW_CONTROL, request, command_name="Window control"
+        )

--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -432,7 +432,10 @@ class PolestarCoordinator(DataUpdateCoordinator):
             access_token=self.api.access_token or "",
             write_access_token=self._pccs_api.access_token,
         )
-        self.cep = CepClient(self.api.access_token or "")
+        self.cep = CepClient(
+            access_token=self.api.access_token or "",
+            write_access_token=self._pccs_api.access_token,
+        )
         self._email: str = entry.data["email"]
         self._password: str = entry.data["password"]
 
@@ -602,6 +605,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
         self.pccs.access_token = self.api.access_token or ""
         self.pccs.write_access_token = self._pccs_api.access_token
         self.cep.access_token = self.api.access_token or ""
+        self.cep.write_access_token = self._pccs_api.access_token
 
     def close(self) -> None:
         """Close gRPC channels."""

--- a/custom_components/polestar_soc/cover.py
+++ b/custom_components/polestar_soc/cover.py
@@ -1,0 +1,116 @@
+"""Cover platform for Polestar — vehicle window control."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import grpc
+from homeassistant.components.cover import (
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .cep import CepError
+from .const import DOMAIN
+from .coordinator import PolestarCoordinator
+
+_WINDOW_KEYS = (
+    "front_left_window",
+    "front_right_window",
+    "rear_left_window",
+    "rear_right_window",
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Polestar cover entities from a config entry."""
+    coordinator: PolestarCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities: list[CoverEntity] = []
+    for vehicle in coordinator.data.get("vehicles", []):
+        vin = vehicle["vin"]
+        entities.append(PolestarWindowCover(coordinator, vehicle, vin))
+
+    async_add_entities(entities)
+
+
+class PolestarWindowCover(CoordinatorEntity[PolestarCoordinator], CoverEntity):
+    """Window cover — shows window state and provides open/close control."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "windows"
+    _attr_device_class = CoverDeviceClass.WINDOW
+    _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+
+    def __init__(
+        self,
+        coordinator: PolestarCoordinator,
+        vehicle: dict,
+        vin: str,
+    ) -> None:
+        """Initialize the cover entity."""
+        super().__init__(coordinator)
+        self._vin = vin
+        self._attr_unique_id = f"{vin}_windows"
+
+        model_name = "Polestar"
+        content = vehicle.get("content")
+        if content and content.get("model"):
+            model_name = content["model"].get("name", model_name)
+        year = vehicle.get("modelYear", "")
+        device_name = f"{model_name} ({year})" if year else model_name
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vin)},
+            name=device_name,
+            manufacturer="Polestar",
+            model=model_name,
+            sw_version=str(year) if year else None,
+        )
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Return true if all vehicle windows are closed."""
+        data = self.coordinator.data
+        if not data:
+            return None
+        exterior = data.get("exterior", {}).get(self._vin)
+        if exterior is None:
+            return None
+        values = [exterior.get(k) for k in _WINDOW_KEYS]
+        if any(v is None or v == 0 for v in values):
+            return None
+        return all(v == 2 for v in values)  # CLOSED
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open all vehicle windows."""
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.cep.window_open,
+                self._vin,
+            )
+        except (grpc.RpcError, CepError) as err:
+            raise HomeAssistantError(f"Failed to open windows: {err}") from err
+        await self.coordinator.async_request_refresh()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close all vehicle windows."""
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.cep.window_close,
+                self._vin,
+            )
+        except (grpc.RpcError, CepError) as err:
+            raise HomeAssistantError(f"Failed to close windows: {err}") from err
+        await self.coordinator.async_request_refresh()

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -687,4 +687,3 @@ class PccsClient:
         """
         request = _build_unlock_request(vin)
         return self._send_invocation(vin, _METHOD_UNLOCK, request, command_name="Unlock")
-

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -29,6 +29,7 @@ from .proto import (
     _get_submessage,
     _identity_deserialize,
     _identity_serialize,
+    _parse_invocation_response,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -224,48 +225,6 @@ def _lock_error_context(data: bytes) -> str:
     if lock_error > 1:
         return f"lock error (code {lock_error})"
     return ""
-
-
-def _parse_invocation_response(data: bytes) -> dict:
-    """Parse ClimatizationResponse → InvocationResponse.
-
-    ClimatizationResponse:
-        field 1: InvocationResponse (message)
-
-    InvocationResponse:
-        field 1: id (string)
-        field 2: vin (string)
-        field 3: status (varint enum)
-        field 4: message (string)
-        field 5: timestamp (int64)
-    """
-    empty = {"id": "", "vin": "", "status": 0, "message": ""}
-    if not data:
-        return empty
-
-    outer = _decode_message(data)
-    inner = _get_submessage(outer, 1)
-    if inner is None:
-        return empty
-
-    id_val = inner.get(1, [b""])[0]
-    if isinstance(id_val, bytes):
-        id_val = id_val.decode("utf-8", errors="replace")
-
-    vin_val = inner.get(2, [b""])[0]
-    if isinstance(vin_val, bytes):
-        vin_val = vin_val.decode("utf-8", errors="replace")
-
-    msg_val = inner.get(4, [b""])[0]
-    if isinstance(msg_val, bytes):
-        msg_val = msg_val.decode("utf-8", errors="replace")
-
-    return {
-        "id": id_val,
-        "vin": vin_val,
-        "status": _get_int(inner, 3, 0),
-        "message": msg_val,
-    }
 
 
 def _parse_target_soc_response(data: bytes) -> dict:

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -687,3 +687,4 @@ class PccsClient:
         """
         request = _build_unlock_request(vin)
         return self._send_invocation(vin, _METHOD_UNLOCK, request, command_name="Unlock")
+

--- a/custom_components/polestar_soc/proto.py
+++ b/custom_components/polestar_soc/proto.py
@@ -137,6 +137,54 @@ def _get_double(fields: dict[int, list], field_number: int) -> float | None:
 
 
 # ---------------------------------------------------------------------------
+# Shared response parsers
+# ---------------------------------------------------------------------------
+
+
+def _parse_invocation_response(data: bytes) -> dict:
+    """Parse an InvocationResponse from a command response wrapper.
+
+    Used by both PCCS and CEP InvocationService commands.
+    The wrapper message (e.g. ClimatizationResponse, WindowControlResponse)
+    has field 1 = InvocationResponse sub-message.
+
+    InvocationResponse:
+        field 1: id (string)
+        field 2: vin (string)
+        field 3: status (varint enum)
+        field 4: message (string)
+        field 5: timestamp (int64)
+    """
+    empty = {"id": "", "vin": "", "status": 0, "message": ""}
+    if not data:
+        return empty
+
+    outer = _decode_message(data)
+    inner = _get_submessage(outer, 1)
+    if inner is None:
+        return empty
+
+    id_val = inner.get(1, [b""])[0]
+    if isinstance(id_val, bytes):
+        id_val = id_val.decode("utf-8", errors="replace")
+
+    vin_val = inner.get(2, [b""])[0]
+    if isinstance(vin_val, bytes):
+        vin_val = vin_val.decode("utf-8", errors="replace")
+
+    msg_val = inner.get(4, [b""])[0]
+    if isinstance(msg_val, bytes):
+        msg_val = msg_val.decode("utf-8", errors="replace")
+
+    return {
+        "id": id_val,
+        "vin": vin_val,
+        "status": _get_int(inner, 3, 0),
+        "message": msg_val,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Raw serializer/deserializer for grpc channel methods
 # ---------------------------------------------------------------------------
 

--- a/custom_components/polestar_soc/strings.json
+++ b/custom_components/polestar_soc/strings.json
@@ -98,6 +98,11 @@
         "name": "Door lock"
       }
     },
+    "cover": {
+      "windows": {
+        "name": "Windows"
+      }
+    },
     "device_tracker": {
       "location": {
         "name": "Location"

--- a/custom_components/polestar_soc/translations/en.json
+++ b/custom_components/polestar_soc/translations/en.json
@@ -98,6 +98,11 @@
         "name": "Door lock"
       }
     },
+    "cover": {
+      "windows": {
+        "name": "Windows"
+      }
+    },
     "device_tracker": {
       "location": {
         "name": "Location"

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -27,7 +27,6 @@ from custom_components.polestar_soc.pccs import (
     _parse_set_charge_timer_response,
     _parse_target_soc_response,
 )
-from custom_components.polestar_soc.proto import _parse_invocation_response
 from custom_components.polestar_soc.proto import (
     _decode_message,
     _decode_varint,
@@ -38,6 +37,7 @@ from custom_components.polestar_soc.proto import (
     _get_bool,
     _get_int,
     _get_submessage,
+    _parse_invocation_response,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -24,10 +24,10 @@ from custom_components.polestar_soc.pccs import (
     _build_unlock_request,
     _lock_error_context,
     _parse_charge_timer_response,
-    _parse_invocation_response,
     _parse_set_charge_timer_response,
     _parse_target_soc_response,
 )
+from custom_components.polestar_soc.proto import _parse_invocation_response
 from custom_components.polestar_soc.proto import (
     _decode_message,
     _decode_varint,


### PR DESCRIPTION
## Summary

- Add a `cover` entity that allows remotely opening and closing all vehicle windows
- Uses CEP InvocationService `WindowControl` method (server-streaming)
- Reports `is_closed` based on all four window states from the existing ExteriorService data
- The API only supports `OPEN_ALL` / `CLOSE_ALL` — no per-window control
- Requires the PCCS 2FA token for commands, same as lock/unlock and climate

## Changes

- **cover.py** (new): `PolestarWindowCover` entity with `CoverDeviceClass.WINDOW`
- **cep.py**: Extended `CepClient` with `write_access_token`, `_send_invocation()`, `window_open()`, `window_close()`, and `CepError`
- **coordinator.py**: Pass write token to `CepClient`
- **__init__.py**: Register `Platform.COVER`
- **strings.json / translations/en.json**: Add "Windows" cover entity name

## Test plan

- [x] Verified CLOSE_ALL command succeeds (SENT → SUCCESS) against live API
- [x] Verified high-level `CepClient.window_close()` works end-to-end
- [x] Verified `is_closed` reads window state correctly from ExteriorService
- [x] All files pass ruff checks