### PR TITLE
Add vehicle availability status entities

### DIFF
--- a/custom_components/polestar_soc/binary_sensor.py
+++ b/custom_components/polestar_soc/binary_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ALARM_STATUS_MAP, DOMAIN, OPEN_STATUS_MAP
+from .const import ALARM_STATUS_MAP, DOMAIN, OPEN_STATUS_MAP, UNAVAILABLE_REASON_MAP
 from .coordinator import PolestarCoordinator
 
 
@@ -25,6 +25,7 @@ class PolestarBinarySensorDescription(BinarySensorEntityDescription):
     """Describe a Polestar binary sensor."""
 
     is_on_fn: Callable[[dict, str], bool | None]
+    extra_attrs_fn: Callable[[dict, str], dict | None] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -58,11 +59,41 @@ def _alarm_is_on(data: dict, vin: str) -> bool | None:
     return val == 2  # TRIGGERED(2)
 
 
+def _availability_is_on(data: dict, vin: str) -> bool | None:
+    """Vehicle available: True=Connected, False=Disconnected, None=Unknown."""
+    availability = data.get("availability", {}).get(vin)
+    if availability is None:
+        return None
+    status = availability.get("availability_status")
+    if status == 1:
+        return True  # AVAILABLE
+    if status == 2:
+        return False  # UNAVAILABLE
+    return None  # UNSPECIFIED or missing
+
+
+def _availability_extra_attrs(data: dict, vin: str) -> dict | None:
+    """Return unavailable_reason as an extra attribute."""
+    availability = data.get("availability", {}).get(vin)
+    if availability is None:
+        return None
+    reason_val = availability.get("unavailable_reason")
+    reason = UNAVAILABLE_REASON_MAP.get(reason_val) if reason_val else None
+    return {"unavailable_reason": reason}
+
+
 # ---------------------------------------------------------------------------
 # Entity descriptions
 # ---------------------------------------------------------------------------
 
 BINARY_SENSOR_DESCRIPTIONS: tuple[PolestarBinarySensorDescription, ...] = (
+    PolestarBinarySensorDescription(
+        key="vehicle_available",
+        translation_key="vehicle_available",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        is_on_fn=_availability_is_on,
+        extra_attrs_fn=_availability_extra_attrs,
+    ),
     PolestarBinarySensorDescription(
         key="front_left_door",
         translation_key="front_left_door",
@@ -228,6 +259,8 @@ class PolestarBinarySensor(CoordinatorEntity[PolestarCoordinator], BinarySensorE
         data = self.coordinator.data
         if not data:
             return None
+        if self.entity_description.extra_attrs_fn is not None:
+            return self.entity_description.extra_attrs_fn(data, self._vin)
         exterior = data.get("exterior", {}).get(self._vin)
         if exterior is None:
             return None

--- a/custom_components/polestar_soc/cep.py
+++ b/custom_components/polestar_soc/cep.py
@@ -42,6 +42,9 @@ _METHOD_GET_CLIMATE = (
 )
 _METHOD_GET_BATTERY = "/services.vehiclestates.battery.BatteryService/GetLatestBattery"
 _METHOD_GET_EXTERIOR = "/services.vehiclestates.exterior.ExteriorService/GetLatestExterior"
+_METHOD_GET_AVAILABILITY = (
+    "/services.vehiclestates.availability.AvailabilityService/GetLatestAvailability"
+)
 _METHOD_GET_LOCATION = "/dtlinternet.DtlInternetService/GetLastKnownLocation"
 _SVC_INVOCATION = "/invocation.InvocationService"
 _METHOD_WINDOW_CONTROL = f"{_SVC_INVOCATION}/WindowControl"
@@ -243,6 +246,32 @@ def _parse_exterior_response(data: bytes) -> dict:
     return result
 
 
+def _parse_availability_response(data: bytes) -> dict:
+    """Parse GetLatestAvailability response.
+
+    Two-level decode: outer envelope has field 3 = Availability state sub-message.
+
+    Availability state fields:
+        field 3: availability_status (varint: 1=AVAILABLE, 2=UNAVAILABLE)
+        field 4: unavailable_reason (varint: 1=NO_INTERNET, 2=POWER_SAVING, ...)
+        field 5: usage_mode (varint: 1=ABANDONED, 2=INACTIVE, ..., 5=DRIVING)
+    """
+    empty = {"availability_status": None, "unavailable_reason": None, "usage_mode": None}
+    if not data:
+        return empty
+
+    outer = _decode_message(data)
+    state = _get_submessage(outer, 3)
+    if state is None:
+        return empty
+
+    return {
+        "availability_status": _get_int(state, 3) or None,
+        "unavailable_reason": _get_int(state, 4) or None,
+        "usage_mode": _get_int(state, 5) or None,
+    }
+
+
 def _parse_location_response(data: bytes) -> dict:
     """Parse GetLastKnownLocation response.
 
@@ -381,6 +410,21 @@ class CepClient:
             return _parse_exterior_response(response)
         except grpc.RpcError as err:
             _LOGGER.warning("CEP GetLatestExterior failed: %s", err)
+            raise
+
+    def get_availability(self, vin: str) -> dict:
+        """Get current vehicle availability state."""
+        channel = self._get_channel()
+        method = channel.unary_unary(
+            _METHOD_GET_AVAILABILITY,
+            request_serializer=_identity_serialize,
+            response_deserializer=_identity_deserialize,
+        )
+        try:
+            response = method(_build_vin_request(vin), metadata=self._metadata(vin), timeout=30)
+            return _parse_availability_response(response)
+        except grpc.RpcError as err:
+            _LOGGER.warning("CEP GetLatestAvailability failed: %s", err)
             raise
 
     def get_location(self, vin: str) -> dict:

--- a/custom_components/polestar_soc/const.py
+++ b/custom_components/polestar_soc/const.py
@@ -123,3 +123,23 @@ ALARM_STATUS_MAP: dict[int, str | None] = {
     1: "Idle",
     2: "Triggered",
 }
+
+# Availability enums (AvailabilityService)
+UNAVAILABLE_REASON_MAP: dict[int, str] = {
+    1: "No internet",
+    2: "Power saving mode",
+    3: "Car in use",
+    4: "OTA installation in progress",
+    5: "Stolen vehicle tracking in progress",
+    6: "Service mode active",
+}
+
+USAGE_MODE_MAP: dict[int, str] = {
+    1: "Abandoned",
+    2: "Inactive",
+    3: "Convenience",
+    4: "Active",
+    5: "Driving",
+    6: "Engine on",
+    7: "Engine off",
+}

--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -524,6 +524,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
                     "cep_battery": {},
                     "location": {},
                     "exterior": {},
+                    "availability": {},
                 }
 
             vins = [v["vin"] for v in vehicles]
@@ -557,6 +558,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
             cep_battery_by_vin: dict = {}
             location_by_vin: dict = {}
             exterior_by_vin: dict = {}
+            availability_by_vin: dict = {}
             for vin in vins:
                 try:
                     climate_by_vin[vin] = self.cep.get_parking_climatization(vin)
@@ -574,6 +576,10 @@ class PolestarCoordinator(DataUpdateCoordinator):
                     exterior_by_vin[vin] = self.cep.get_exterior(vin)
                 except Exception:
                     _LOGGER.debug("Failed to fetch CEP exterior for %s", vin)
+                try:
+                    availability_by_vin[vin] = self.cep.get_availability(vin)
+                except Exception:
+                    _LOGGER.debug("Failed to fetch CEP availability for %s", vin)
 
             return {
                 "vehicles": vehicles,
@@ -585,6 +591,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 "cep_battery": cep_battery_by_vin,
                 "location": location_by_vin,
                 "exterior": exterior_by_vin,
+                "availability": availability_by_vin,
             }
 
         return await self.hass.async_add_executor_job(_do_fetch)

--- a/custom_components/polestar_soc/sensor.py
+++ b/custom_components/polestar_soc/sensor.py
@@ -18,7 +18,13 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CLIMATE_RUNNING_STATUS_MAP, DOMAIN, HEATING_INTENSITY_MAP
+from .const import (
+    CLIMATE_RUNNING_STATUS_MAP,
+    DOMAIN,
+    HEATING_INTENSITY_MAP,
+    UNAVAILABLE_REASON_MAP,
+    USAGE_MODE_MAP,
+)
 from .coordinator import PolestarCoordinator
 
 
@@ -84,6 +90,26 @@ def _climate_heating(key: str) -> Callable[[dict, str], str | None]:
     return _value_fn
 
 
+def _usage_mode(data: dict, vin: str) -> str | None:
+    availability = data.get("availability", {}).get(vin)
+    if availability is None:
+        return None
+    val = availability.get("usage_mode")
+    if val is None:
+        return None
+    return USAGE_MODE_MAP.get(val)
+
+
+def _unavailable_reason(data: dict, vin: str) -> str | None:
+    availability = data.get("availability", {}).get(vin)
+    if availability is None:
+        return None
+    val = availability.get("unavailable_reason")
+    if val is None:
+        return None
+    return UNAVAILABLE_REASON_MAP.get(val)
+
+
 def _estimated_range(data: dict, vin: str) -> int | None:
     cep_battery = data.get("cep_battery", {}).get(vin)
     if cep_battery is None:
@@ -94,6 +120,8 @@ def _estimated_range(data: dict, vin: str) -> int | None:
 # Options lists for ENUM sensors
 _CLIMATE_STATUS_OPTIONS = list(CLIMATE_RUNNING_STATUS_MAP.values())
 _HEATING_INTENSITY_OPTIONS = list(HEATING_INTENSITY_MAP.values())
+_USAGE_MODE_OPTIONS = list(USAGE_MODE_MAP.values())
+_UNAVAILABLE_REASON_OPTIONS = list(UNAVAILABLE_REASON_MAP.values())
 
 SENSOR_DESCRIPTIONS: tuple[PolestarSensorDescription, ...] = (
     PolestarSensorDescription(
@@ -174,6 +202,21 @@ SENSOR_DESCRIPTIONS: tuple[PolestarSensorDescription, ...] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=_estimated_range,
+    ),
+    PolestarSensorDescription(
+        key="usage_mode",
+        translation_key="usage_mode",
+        device_class=SensorDeviceClass.ENUM,
+        options=_USAGE_MODE_OPTIONS,
+        value_fn=_usage_mode,
+    ),
+    PolestarSensorDescription(
+        key="unavailable_reason",
+        translation_key="unavailable_reason",
+        device_class=SensorDeviceClass.ENUM,
+        options=_UNAVAILABLE_REASON_OPTIONS,
+        entity_registry_enabled_default=False,
+        value_fn=_unavailable_reason,
     ),
 )
 

--- a/custom_components/polestar_soc/strings.json
+++ b/custom_components/polestar_soc/strings.json
@@ -70,6 +70,12 @@
       },
       "estimated_range": {
         "name": "Estimated range"
+      },
+      "usage_mode": {
+        "name": "Usage mode"
+      },
+      "unavailable_reason": {
+        "name": "Unavailable reason"
       }
     },
     "number": {
@@ -109,6 +115,9 @@
       }
     },
     "binary_sensor": {
+      "vehicle_available": {
+        "name": "Vehicle available"
+      },
       "front_left_door": {
         "name": "Front left door"
       },

--- a/custom_components/polestar_soc/translations/en.json
+++ b/custom_components/polestar_soc/translations/en.json
@@ -70,6 +70,12 @@
       },
       "estimated_range": {
         "name": "Estimated range"
+      },
+      "usage_mode": {
+        "name": "Usage mode"
+      },
+      "unavailable_reason": {
+        "name": "Unavailable reason"
       }
     },
     "number": {
@@ -109,6 +115,9 @@
       }
     },
     "binary_sensor": {
+      "vehicle_available": {
+        "name": "Vehicle available"
+      },
       "front_left_door": {
         "name": "Front left door"
       },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,16 @@ def sample_charge_timer():
 
 
 @pytest.fixture
+def sample_availability():
+    """Return a sample availability state dict (as returned by CepClient)."""
+    return {
+        "availability_status": 1,  # AVAILABLE
+        "unavailable_reason": None,
+        "usage_mode": 2,  # INACTIVE
+    }
+
+
+@pytest.fixture
 def sample_coordinator_data(
     sample_vehicle,
     sample_battery,
@@ -125,6 +135,7 @@ def sample_coordinator_data(
     sample_cep_battery,
     sample_location,
     sample_exterior,
+    sample_availability,
 ):
     """Return a full coordinator data dict combining all sources."""
     vin = sample_vehicle["vin"]
@@ -138,4 +149,5 @@ def sample_coordinator_data(
         "cep_battery": {vin: sample_cep_battery},
         "location": {vin: sample_location},
         "exterior": {vin: sample_exterior},
+        "availability": {vin: sample_availability},
     }

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -133,11 +133,11 @@ class TestNoneHandling:
 
 class TestDescriptionCounts:
     def test_total_descriptions(self):
-        assert len(BINARY_SENSOR_DESCRIPTIONS) == 13
+        assert len(BINARY_SENSOR_DESCRIPTIONS) == 14
 
     def test_enabled_by_default_count(self):
         enabled = [d for d in BINARY_SENSOR_DESCRIPTIONS if d.entity_registry_enabled_default]
-        assert len(enabled) == 4  # 4 doors
+        assert len(enabled) == 5  # vehicle_available + 4 doors
 
     def test_disabled_by_default_count(self):
         disabled = [d for d in BINARY_SENSOR_DESCRIPTIONS if not d.entity_registry_enabled_default]

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -112,6 +112,40 @@ class TestExtraStateAttributes:
         assert sensor.extra_state_attributes is None
 
 
+class TestAvailabilityIsOn:
+    def test_available(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "vehicle_available")
+        assert sensor.is_on is True  # fixture has AVAILABLE(1)
+
+    def test_unavailable(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["availability"][VIN]["availability_status"] = 2  # UNAVAILABLE
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "vehicle_available")
+        assert sensor.is_on is False
+
+    def test_unspecified(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["availability"][VIN]["availability_status"] = None
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "vehicle_available")
+        assert sensor.is_on is None
+
+    def test_no_availability_data(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["availability"] = {}
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "vehicle_available")
+        assert sensor.is_on is None
+
+    def test_extra_attrs_with_reason(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["availability"][VIN]["unavailable_reason"] = 2  # POWER_SAVING
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "vehicle_available")
+        assert sensor.extra_state_attributes == {"unavailable_reason": "Power saving mode"}
+
+    def test_extra_attrs_no_reason(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "vehicle_available")
+        assert sensor.extra_state_attributes == {"unavailable_reason": None}
+
+    def test_device_class_connectivity(self, sample_coordinator_data, sample_vehicle):
+        sensor = _make_sensor(sample_coordinator_data, sample_vehicle, VIN, "vehicle_available")
+        assert sensor.device_class == BinarySensorDeviceClass.CONNECTIVITY
+
+
 class TestNoneHandling:
     def test_none_when_no_coordinator_data(self, sample_vehicle):
         sensor = _make_sensor(None, sample_vehicle, VIN, "front_left_door")

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -9,6 +9,7 @@ from custom_components.polestar_soc.cep import (
     _build_vin_request,
     _format_climate_status,
     _format_heating_intensity,
+    _parse_availability_response,
     _parse_battery_response,
     _parse_climate_response,
     _parse_exterior_response,
@@ -342,3 +343,90 @@ class TestParseExteriorResponse:
         state = _get_submessage(outer, 3)
         assert state is not None
         assert 2 in state  # central_lock field
+
+
+# ---------------------------------------------------------------------------
+# Availability tests
+# ---------------------------------------------------------------------------
+
+
+def _build_availability_state(field_values: dict[int, int]) -> bytes:
+    """Build an Availability state sub-message from {field_number: varint_value}."""
+    data = b""
+    for field_num in sorted(field_values):
+        data += _encode_field_varint(field_num, field_values[field_num])
+    return data
+
+
+def _build_availability_payload(vin: str, field_values: dict[int, int]) -> bytes:
+    """Build a synthetic GetLatestAvailability response with two-level envelope."""
+    state_bytes = _build_availability_state(field_values)
+    data = _encode_field_bytes(2, vin.encode("utf-8"))
+    data += _encode_field_bytes(3, state_bytes)
+    return data
+
+
+AVAILABILITY_AVAILABLE = _build_availability_payload(
+    TEST_VIN,
+    {
+        3: 1,  # availability_status: AVAILABLE
+        5: 2,  # usage_mode: INACTIVE
+    },
+)
+
+AVAILABILITY_UNAVAILABLE = _build_availability_payload(
+    TEST_VIN,
+    {
+        3: 2,  # availability_status: UNAVAILABLE
+        4: 2,  # unavailable_reason: POWER_SAVING_MODE
+        5: 1,  # usage_mode: ABANDONED
+    },
+)
+
+
+class TestParseAvailabilityResponse:
+    def test_available_vehicle(self):
+        result = _parse_availability_response(AVAILABILITY_AVAILABLE)
+        assert result["availability_status"] == 1  # AVAILABLE
+        assert result["unavailable_reason"] is None  # not set
+        assert result["usage_mode"] == 2  # INACTIVE
+
+    def test_unavailable_vehicle(self):
+        result = _parse_availability_response(AVAILABILITY_UNAVAILABLE)
+        assert result["availability_status"] == 2  # UNAVAILABLE
+        assert result["unavailable_reason"] == 2  # POWER_SAVING_MODE
+        assert result["usage_mode"] == 1  # ABANDONED
+
+    def test_unspecified_values(self):
+        """Value 0 for any field returns None."""
+        payload = _build_availability_payload(
+            TEST_VIN,
+            {3: 0, 4: 0, 5: 0},
+        )
+        result = _parse_availability_response(payload)
+        assert result["availability_status"] is None
+        assert result["unavailable_reason"] is None
+        assert result["usage_mode"] is None
+
+    def test_empty_response(self):
+        result = _parse_availability_response(b"")
+        assert result["availability_status"] is None
+        assert result["unavailable_reason"] is None
+        assert result["usage_mode"] is None
+
+    def test_missing_state_submessage(self):
+        """Response with VIN but no field 3 returns all None."""
+        data = _encode_field_bytes(2, TEST_VIN.encode("utf-8"))
+        result = _parse_availability_response(data)
+        assert result["availability_status"] is None
+        assert result["unavailable_reason"] is None
+        assert result["usage_mode"] is None
+
+    def test_two_level_envelope(self):
+        """Verify outer envelope has field 2=VIN and field 3=Availability state."""
+        outer = _decode_message(AVAILABILITY_AVAILABLE)
+        assert outer[2][0] == TEST_VIN.encode("utf-8")
+        assert isinstance(outer[3][0], (bytes, bytearray))
+        state = _get_submessage(outer, 3)
+        assert state is not None
+        assert 3 in state  # availability_status field


### PR DESCRIPTION
## Summary
- Add **binary sensor** (`vehicle_available`) with CONNECTIVITY device class — shows Connected/Disconnected based on whether the car is reachable for remote commands
- Add **sensor** (`usage_mode`) — ENUM showing current vehicle state: Abandoned, Inactive, Convenience, Active, Driving
- Add **sensor** (`unavailable_reason`) — ENUM (disabled by default) showing why the vehicle is offline: No internet, Power saving, Car in use, OTA in progress, etc.
- Binary sensor includes `unavailable_reason` as an extra state attribute for quick visibility

## Test plan
- [x] All 249 unit tests pass (6 new availability parser tests + 2 updated count tests)
- [x] Verified against real vehicle API — returns AVAILABLE + Abandoned for parked car
- [ ] Manual HA deployment to verify entity display names and state transitions