### PR TITLE
Add parking climate timer entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ research/
 plans/
 scripts/
 pr-reviews/
+android-decompiled/

--- a/custom_components/polestar_soc/const.py
+++ b/custom_components/polestar_soc/const.py
@@ -143,3 +143,14 @@ USAGE_MODE_MAP: dict[int, str] = {
     6: "Engine on",
     7: "Engine off",
 }
+
+# Weekday enum (ParkingClimateTimer)
+WEEKDAY_MAP: dict[int, str] = {
+    1: "Monday",
+    2: "Tuesday",
+    3: "Wednesday",
+    4: "Thursday",
+    5: "Friday",
+    6: "Saturday",
+    7: "Sunday",
+}

--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -520,6 +520,8 @@ class PolestarCoordinator(DataUpdateCoordinator):
                     "odometer": {},
                     "target_soc": {},
                     "charge_timer": {},
+                    "climate_timers": {},
+                    "climate_timer_settings": {},
                     "climate": {},
                     "cep_battery": {},
                     "location": {},
@@ -540,9 +542,11 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 if o:
                     odometer_by_vin[o["vin"]] = o
 
-            # Fetch PCCS data (charge target + timer) per VIN
+            # Fetch PCCS data (charge target + timer + climate timers) per VIN
             target_soc_by_vin: dict = {}
             charge_timer_by_vin: dict = {}
+            climate_timers_by_vin: dict = {}
+            climate_timer_settings_by_vin: dict = {}
             for vin in vins:
                 try:
                     target_soc_by_vin[vin] = self.pccs.get_target_soc(vin)
@@ -552,6 +556,16 @@ class PolestarCoordinator(DataUpdateCoordinator):
                     charge_timer_by_vin[vin] = self.pccs.get_global_charge_timer(vin)
                 except Exception:
                     _LOGGER.debug("Failed to fetch PCCS charge timer for %s", vin)
+                try:
+                    climate_timers_by_vin[vin] = self.pccs.get_parking_climate_timers(vin)
+                except Exception:
+                    _LOGGER.debug("Failed to fetch PCCS climate timers for %s", vin)
+                try:
+                    climate_timer_settings_by_vin[vin] = (
+                        self.pccs.get_parking_climate_timer_settings(vin)
+                    )
+                except Exception:
+                    _LOGGER.debug("Failed to fetch PCCS climate timer settings for %s", vin)
 
             # Fetch CEP data (climate status + battery + location) per VIN
             climate_by_vin: dict = {}
@@ -587,6 +601,8 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 "odometer": odometer_by_vin,
                 "target_soc": target_soc_by_vin,
                 "charge_timer": charge_timer_by_vin,
+                "climate_timers": climate_timers_by_vin,
+                "climate_timer_settings": climate_timer_settings_by_vin,
                 "climate": climate_by_vin,
                 "cep_battery": cep_battery_by_vin,
                 "location": location_by_vin,

--- a/custom_components/polestar_soc/number.py
+++ b/custom_components/polestar_soc/number.py
@@ -98,9 +98,7 @@ class PolestarChargeLimitNumber(CoordinatorEntity[PolestarCoordinator], NumberEn
         await self.coordinator.async_request_refresh()
 
 
-class PolestarClimateTimerTemperatureNumber(
-    CoordinatorEntity[PolestarCoordinator], NumberEntity
-):
+class PolestarClimateTimerTemperatureNumber(CoordinatorEntity[PolestarCoordinator], NumberEntity):
     """Climate timer temperature — sets the target cabin temperature for scheduled climate."""
 
     _attr_has_entity_name = True
@@ -158,7 +156,5 @@ class PolestarClimateTimerTemperatureNumber(
                 value,
             )
         except (grpc.RpcError, PccsError) as err:
-            raise HomeAssistantError(
-                f"Failed to set climate timer temperature: {err}"
-            ) from err
+            raise HomeAssistantError(f"Failed to set climate timer temperature: {err}") from err
         await self.coordinator.async_request_refresh()

--- a/custom_components/polestar_soc/number.py
+++ b/custom_components/polestar_soc/number.py
@@ -7,7 +7,7 @@ import logging
 import grpc
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import PolestarCoordinator
+from .pccs import PccsError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,10 +29,11 @@ async def async_setup_entry(
     """Set up Polestar number entities from a config entry."""
     coordinator: PolestarCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    entities: list[PolestarChargeLimitNumber] = []
+    entities: list[NumberEntity] = []
     for vehicle in coordinator.data.get("vehicles", []):
         vin = vehicle["vin"]
         entities.append(PolestarChargeLimitNumber(coordinator, vehicle, vin))
+        entities.append(PolestarClimateTimerTemperatureNumber(coordinator, vehicle, vin))
 
     async_add_entities(entities)
 
@@ -93,4 +95,70 @@ class PolestarChargeLimitNumber(CoordinatorEntity[PolestarCoordinator], NumberEn
             )
         except grpc.RpcError as err:
             raise HomeAssistantError(f"Failed to set charge limit: {err}") from err
+        await self.coordinator.async_request_refresh()
+
+
+class PolestarClimateTimerTemperatureNumber(
+    CoordinatorEntity[PolestarCoordinator], NumberEntity
+):
+    """Climate timer temperature — sets the target cabin temperature for scheduled climate."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "climate_timer_temperature"
+    _attr_native_min_value = 15
+    _attr_native_max_value = 28
+    _attr_native_step = 0.5
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_device_class = NumberDeviceClass.TEMPERATURE
+    _attr_mode = NumberMode.SLIDER
+
+    def __init__(
+        self,
+        coordinator: PolestarCoordinator,
+        vehicle: dict,
+        vin: str,
+    ) -> None:
+        """Initialize the climate timer temperature entity."""
+        super().__init__(coordinator)
+        self._vin = vin
+        self._attr_unique_id = f"{vin}_climate_timer_temperature"
+
+        model_name = "Polestar"
+        content = vehicle.get("content")
+        if content and content.get("model"):
+            model_name = content["model"].get("name", model_name)
+        year = vehicle.get("modelYear", "")
+        device_name = f"{model_name} ({year})" if year else model_name
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vin)},
+            name=device_name,
+            manufacturer="Polestar",
+            model=model_name,
+            sw_version=str(year) if year else None,
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current climate timer temperature."""
+        data = self.coordinator.data
+        if not data:
+            return None
+        settings = data.get("climate_timer_settings", {}).get(self._vin)
+        if settings is None:
+            return None
+        return settings.get("temperature")
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the climate timer temperature via PCCS."""
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.pccs.set_parking_climate_timer_settings,
+                self._vin,
+                value,
+            )
+        except (grpc.RpcError, PccsError) as err:
+            raise HomeAssistantError(
+                f"Failed to set climate timer temperature: {err}"
+            ) from err
         await self.coordinator.async_request_refresh()

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -818,6 +818,7 @@ class PccsClient:
         request = _build_set_climate_timer_settings_request(vin, temperature)
         try:
             response = method(request, metadata=self._write_metadata(vin), timeout=30)
+            # SetTimerSettingsResponse has the same wire layout as SetTimersResponse
             result = _parse_set_climate_timers_response(response)
         except grpc.RpcError as err:
             _LOGGER.warning("PCCS SetTimerSettings (climate) failed: %s", err)

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -21,11 +21,15 @@ from homeassistant.exceptions import HomeAssistantError
 from .const import _INVOCATION_INTERMEDIATE_STATUSES, INVOCATION_STATUS_MAP, PCCS_API_HOST
 from .proto import (
     _decode_message,
+    _decode_packed_varints,
     _encode_field_bytes,
     _encode_field_fixed32,
     _encode_field_varint,
+    _encode_packed_varints,
     _get_bool,
+    _get_float,
     _get_int,
+    _get_string,
     _get_submessage,
     _identity_deserialize,
     _identity_serialize,
@@ -50,12 +54,17 @@ class PccsError(HomeAssistantError):
 # gRPC service method paths
 _SVC_TARGET_SOC = "/pccs.chronos.services.v1.TargetSocService"
 _SVC_CHARGE_TIMER = "/pccs.chronos.services.v2.GlobalChargeTimerService"
+_SVC_CLIMATE_TIMER = "/pccs.chronos.services.v1.ParkingClimateTimerService"
 _SVC_INVOCATION = "/pccs.invocation.v1.InvocationService"
 
 _METHOD_GET_TARGET_SOC = f"{_SVC_TARGET_SOC}/GetTargetSoc"
 _METHOD_SET_TARGET_SOC = f"{_SVC_TARGET_SOC}/SetTargetSoc"
 _METHOD_GET_CHARGE_TIMER = f"{_SVC_CHARGE_TIMER}/GetGlobalChargeTimerStream"
 _METHOD_SET_CHARGE_TIMER = f"{_SVC_CHARGE_TIMER}/SetGlobalChargeTimer"
+_METHOD_GET_CLIMATE_TIMERS = f"{_SVC_CLIMATE_TIMER}/GetTimers"
+_METHOD_SET_CLIMATE_TIMERS = f"{_SVC_CLIMATE_TIMER}/SetTimers"
+_METHOD_GET_CLIMATE_TIMER_SETTINGS = f"{_SVC_CLIMATE_TIMER}/GetTimerSettings"
+_METHOD_SET_CLIMATE_TIMER_SETTINGS = f"{_SVC_CLIMATE_TIMER}/SetTimerSettings"
 _METHOD_CLIMATIZATION_START = f"{_SVC_INVOCATION}/ClimatizationStart"
 _METHOD_CLIMATIZATION_STOP = f"{_SVC_INVOCATION}/ClimatizationStop"
 _METHOD_LOCK = f"{_SVC_INVOCATION}/Lock"
@@ -343,6 +352,190 @@ def _parse_set_charge_timer_response(data: bytes) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Parking climate timer builders / parsers
+# ---------------------------------------------------------------------------
+
+
+def _parse_single_climate_timer(data: bytes) -> dict:
+    """Parse a single ParkingClimateTimer sub-message into a dict.
+
+    ParkingClimateTimer:
+        field 1: timer_id (string)
+        field 2: index (int32, 1-5)
+        field 3: ready_at (DailyTime message)
+        field 4: activated (bool)
+        field 5: repeat (bool)
+        field 6: weekdays (packed repeated Weekday enum)
+        field 7: metadata (message, opaque)
+        field 8: start_date (message, opaque)
+    """
+    fields = _decode_message(data)
+    ready_at = _get_submessage(fields, 3)
+
+    # Weekdays: packed repeated varint in field 6
+    weekdays_raw = fields.get(6, [None])[0]
+    weekdays: list[int] = []
+    if isinstance(weekdays_raw, (bytes, bytearray)):
+        weekdays = _decode_packed_varints(weekdays_raw)
+
+    return {
+        "timer_id": _get_string(fields, 1),
+        "index": _get_int(fields, 2),
+        "hour": _get_int(ready_at, 1) if ready_at else 0,
+        "minute": _get_int(ready_at, 2) if ready_at else 0,
+        "activated": _get_bool(fields, 4),
+        "repeat": _get_bool(fields, 5),
+        "weekdays": weekdays,
+        "metadata_raw": fields.get(7, [None])[0],
+        "start_date_raw": fields.get(8, [None])[0],
+    }
+
+
+def _parse_climate_timers_response(data: bytes) -> list[dict]:
+    """Parse GetParkingClimateTimersResponse.
+
+    Response structure:
+        field 1: id (string)
+        field 2: vin (string)
+        field 3: repeated ParkingClimateTimer (baseline)
+        field 4: repeated ParkingClimateTimer (pending)
+        field 5: repeated ParkingClimateTimer (pending delete)
+        field 6: updatedAt (varint)
+
+    Prefers pending (field 4) over baseline (field 3).
+    """
+    if not data:
+        return []
+
+    fields = _decode_message(data)
+
+    # Prefer pending timers (field 4) over baseline (field 3)
+    timer_list = fields.get(4) or fields.get(3) or []
+    timers: list[dict] = []
+    for raw in timer_list:
+        if isinstance(raw, (bytes, bytearray)):
+            timers.append(_parse_single_climate_timer(raw))
+
+    return timers
+
+
+def _parse_climate_timer_settings_response(data: bytes) -> dict:
+    """Parse GetParkingClimateTimerSettingsResponse.
+
+    Response structure:
+        field 1: TimerSettings (baseline)
+        field 2: TimerSettings (pending)
+        field 3: updatedAt (varint)
+
+    TimerSettings:
+        field 3: requested_compartment_temperature_celsius (float/fixed32)
+        field 4: is_compartment_temperature_requested (bool)
+
+    Prefers pending (field 2) over baseline (field 1).
+    """
+    empty: dict = {"temperature": None}
+    if not data:
+        return empty
+
+    fields = _decode_message(data)
+    settings = _get_submessage(fields, 2) or _get_submessage(fields, 1)
+    if not settings:
+        return empty
+
+    return {
+        "temperature": _get_float(settings, 3),
+    }
+
+
+def _parse_set_climate_timers_response(data: bytes) -> dict:
+    """Parse SetParkingClimateTimersResponse.
+
+    Response structure (different from SetGlobalChargeTimerResponse!):
+        field 1: id (string)
+        field 2: vin (string)
+        field 3: status (varint enum: 0=UNKNOWN_ERROR, 1=SUCCESS,
+                 2=VALIDATION_ERROR, 3=INTERNAL_ERROR)
+        field 4: message (string)
+    """
+    if not data:
+        return {"id": "", "vin": "", "status": 0, "message": ""}
+
+    fields = _decode_message(data)
+
+    return {
+        "id": _get_string(fields, 1),
+        "vin": _get_string(fields, 2),
+        "status": _get_int(fields, 3, 0),
+        "message": _get_string(fields, 4),
+    }
+
+
+def _build_parking_climate_timer(timer: dict) -> bytes:
+    """Encode a single ParkingClimateTimer dict to protobuf bytes.
+
+    All fields are preserved for round-tripping through SetTimers.
+    """
+    msg = b""
+    # field 1: timer_id (string)
+    timer_id = timer.get("timer_id", "")
+    if timer_id:
+        msg += _encode_field_bytes(1, timer_id.encode("utf-8"))
+    # field 2: index (varint)
+    index = timer.get("index", 0)
+    if index:
+        msg += _encode_field_varint(2, index)
+    # field 3: ready_at (DailyTime sub-message)
+    msg += _encode_field_bytes(3, _build_time_of_day(timer.get("hour", 0), timer.get("minute", 0)))
+    # field 4: activated (bool/varint)
+    if timer.get("activated"):
+        msg += _encode_field_varint(4, 1)
+    # field 5: repeat (bool/varint)
+    if timer.get("repeat"):
+        msg += _encode_field_varint(5, 1)
+    # field 6: weekdays (packed repeated varint)
+    weekdays = timer.get("weekdays", [])
+    if weekdays:
+        msg += _encode_packed_varints(6, weekdays)
+    # field 7: metadata (raw bytes passthrough)
+    metadata_raw = timer.get("metadata_raw")
+    if isinstance(metadata_raw, (bytes, bytearray)):
+        msg += _encode_field_bytes(7, metadata_raw)
+    # field 8: start_date (raw bytes passthrough)
+    start_date_raw = timer.get("start_date_raw")
+    if isinstance(start_date_raw, (bytes, bytearray)):
+        msg += _encode_field_bytes(8, start_date_raw)
+    return msg
+
+
+def _build_set_climate_timers_request(vin: str, timers: list[dict]) -> bytes:
+    """Build SetParkingClimateTimersRequest bytes.
+
+    Args:
+        vin: Vehicle identification number.
+        timers: Complete list of timer dicts (replace-all semantics).
+    """
+    msg = _encode_field_bytes(1, _build_chronos_request(vin))
+    for timer in timers:
+        msg += _encode_field_bytes(2, _build_parking_climate_timer(timer))
+    # field 3: time_is_utc0 — omitted (false is proto3 default)
+    return msg
+
+
+def _build_set_climate_timer_settings_request(vin: str, temperature: float) -> bytes:
+    """Build SetParkingClimateTimerSettingsRequest bytes.
+
+    Args:
+        vin: Vehicle identification number.
+        temperature: Target compartment temperature in Celsius.
+    """
+    # TimerSettings sub-message: field 3 = temperature (fixed32), field 4 = is_requested (bool)
+    settings = _encode_field_fixed32(3, temperature) + _encode_field_varint(4, 1)
+    msg = _encode_field_bytes(1, _build_chronos_request(vin))
+    msg += _encode_field_bytes(2, settings)
+    return msg
+
+
+# ---------------------------------------------------------------------------
 # PccsClient
 # ---------------------------------------------------------------------------
 
@@ -528,6 +721,116 @@ class PccsClient:
 
         if result.get("has_not_changed"):
             _LOGGER.debug("SetGlobalChargeTimer: values unchanged")
+
+        return result
+
+    # -- Parking Climate Timers ----------------------------------------------
+
+    def get_parking_climate_timers(self, vin: str) -> list[dict]:
+        """Get parking climate timers for a vehicle.
+
+        GetTimers is a server-streaming RPC; we take the first response.
+        """
+        channel = self._get_channel()
+        method = channel.unary_stream(
+            _METHOD_GET_CLIMATE_TIMERS,
+            request_serializer=_identity_serialize,
+            response_deserializer=_identity_deserialize,
+        )
+        request = _build_get_request(vin)
+        try:
+            responses = method(request, metadata=self._metadata(vin), timeout=30)
+            for response in responses:
+                return _parse_climate_timers_response(response)
+            return []
+        except grpc.RpcError as err:
+            _LOGGER.warning("PCCS GetTimers (climate) failed: %s", err)
+            raise
+
+    def set_parking_climate_timers(self, vin: str, timers: list[dict]) -> dict:
+        """Set parking climate timers for a vehicle (replace-all).
+
+        SetTimers is a server-streaming RPC.
+        Requires the PCCS 2FA token (customer:attributes:write scope).
+        """
+        channel = self._get_channel()
+        method = channel.unary_stream(
+            _METHOD_SET_CLIMATE_TIMERS,
+            request_serializer=_identity_serialize,
+            response_deserializer=_identity_deserialize,
+        )
+        request = _build_set_climate_timers_request(vin, timers)
+        try:
+            responses = method(request, metadata=self._write_metadata(vin), timeout=30)
+            for response in responses:
+                result = _parse_set_climate_timers_response(response)
+                break
+            else:
+                result = _parse_set_climate_timers_response(b"")
+        except grpc.RpcError as err:
+            _LOGGER.warning("PCCS SetTimers (climate) failed: %s", err)
+            raise
+
+        status = result.get("status", 0)
+        if status != 1:  # Not SUCCESS
+            status_name = _RESPONSE_STATUS_NAMES.get(status, f"STATUS_{status}")
+            server_msg = result.get("message", "")
+            msg = f"SetTimers (climate) failed: {status_name}"
+            if server_msg:
+                msg += f" - {server_msg}"
+            raise PccsError(msg)
+
+        return result
+
+    def get_parking_climate_timer_settings(self, vin: str) -> dict:
+        """Get parking climate timer settings for a vehicle.
+
+        GetTimerSettings is a server-streaming RPC; we take the first response.
+        """
+        channel = self._get_channel()
+        method = channel.unary_stream(
+            _METHOD_GET_CLIMATE_TIMER_SETTINGS,
+            request_serializer=_identity_serialize,
+            response_deserializer=_identity_deserialize,
+        )
+        request = _build_get_request(vin)
+        try:
+            responses = method(request, metadata=self._metadata(vin), timeout=30)
+            for response in responses:
+                return _parse_climate_timer_settings_response(response)
+            return _parse_climate_timer_settings_response(b"")
+        except grpc.RpcError as err:
+            _LOGGER.warning("PCCS GetTimerSettings (climate) failed: %s", err)
+            raise
+
+    def set_parking_climate_timer_settings(self, vin: str, temperature: float) -> dict:
+        """Set parking climate timer settings for a vehicle.
+
+        SetTimerSettings is a UNARY RPC (not streaming).
+        Requires the PCCS 2FA token (customer:attributes:write scope).
+        """
+        channel = self._get_channel()
+        method = channel.unary_unary(
+            _METHOD_SET_CLIMATE_TIMER_SETTINGS,
+            request_serializer=_identity_serialize,
+            response_deserializer=_identity_deserialize,
+        )
+        request = _build_set_climate_timer_settings_request(vin, temperature)
+        try:
+            response = method(request, metadata=self._write_metadata(vin), timeout=30)
+            result = _parse_set_climate_timers_response(response)
+        except grpc.RpcError as err:
+            _LOGGER.warning("PCCS SetTimerSettings (climate) failed: %s", err)
+            raise
+
+        status = result.get("status", 0)
+        if status != 1:  # Not SUCCESS
+            status_name = _RESPONSE_STATUS_NAMES.get(status, f"STATUS_{status}")
+            server_msg = result.get("message", "")
+            msg = f"SetTimerSettings (climate) failed: {status_name}"
+            if server_msg:
+                msg += f" - {server_msg}"
+            raise PccsError(msg)
 
         return result
 

--- a/custom_components/polestar_soc/proto.py
+++ b/custom_components/polestar_soc/proto.py
@@ -121,6 +121,29 @@ def _get_submessage(fields: dict[int, list], field_number: int) -> dict[int, lis
     return None
 
 
+def _get_string(fields: dict[int, list], field_number: int, default: str = "") -> str:
+    """Extract and decode a UTF-8 string from a length-delimited field."""
+    vals = fields.get(field_number)
+    if vals and isinstance(vals[0], (bytes, bytearray)):
+        return vals[0].decode("utf-8", errors="replace")
+    return default
+
+
+def _get_float(fields: dict[int, list], field_number: int) -> float | None:
+    """Extract a float (IEEE 754) from a fixed32 field.
+
+    _decode_message stores wire type 5 as uint32.  This helper reinterprets
+    the raw bits as a single-precision float.
+    """
+    vals = fields.get(field_number)
+    if not vals:
+        return None
+    raw = vals[0]
+    if isinstance(raw, int):
+        return struct.unpack("<f", struct.pack("<I", raw))[0]
+    return None
+
+
 def _get_double(fields: dict[int, list], field_number: int) -> float | None:
     """Extract a double (IEEE 754) from a fixed64 field.
 
@@ -134,6 +157,26 @@ def _get_double(fields: dict[int, list], field_number: int) -> float | None:
     if isinstance(raw, int):
         return struct.unpack("<d", struct.pack("<Q", raw))[0]
     return None
+
+
+def _decode_packed_varints(data: bytes) -> list[int]:
+    """Decode a packed repeated varint field into a list of integers."""
+    values: list[int] = []
+    pos = 0
+    while pos < len(data):
+        value, pos = _decode_varint(data, pos)
+        values.append(value)
+    return values
+
+
+def _encode_packed_varints(field_number: int, values: list[int]) -> bytes:
+    """Encode a list of integers as a packed repeated varint field."""
+    if not values:
+        return b""
+    packed = b""
+    for v in values:
+        packed += _encode_varint(v)
+    return _encode_field_bytes(field_number, packed)
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/polestar_soc/strings.json
+++ b/custom_components/polestar_soc/strings.json
@@ -81,6 +81,9 @@
     "number": {
       "charge_limit": {
         "name": "Charge limit"
+      },
+      "climate_timer_temperature": {
+        "name": "Climate timer temperature"
       }
     },
     "time": {
@@ -89,6 +92,21 @@
       },
       "charging_end_time": {
         "name": "Charging end time"
+      },
+      "climate_timer_1_time": {
+        "name": "Climate timer 1 time"
+      },
+      "climate_timer_2_time": {
+        "name": "Climate timer 2 time"
+      },
+      "climate_timer_3_time": {
+        "name": "Climate timer 3 time"
+      },
+      "climate_timer_4_time": {
+        "name": "Climate timer 4 time"
+      },
+      "climate_timer_5_time": {
+        "name": "Climate timer 5 time"
       }
     },
     "switch": {
@@ -97,6 +115,21 @@
       },
       "climate": {
         "name": "Climate"
+      },
+      "climate_timer_1": {
+        "name": "Climate timer 1"
+      },
+      "climate_timer_2": {
+        "name": "Climate timer 2"
+      },
+      "climate_timer_3": {
+        "name": "Climate timer 3"
+      },
+      "climate_timer_4": {
+        "name": "Climate timer 4"
+      },
+      "climate_timer_5": {
+        "name": "Climate timer 5"
       }
     },
     "lock": {

--- a/custom_components/polestar_soc/switch.py
+++ b/custom_components/polestar_soc/switch.py
@@ -267,9 +267,7 @@ class PolestarClimateTimerSwitch(CoordinatorEntity[PolestarCoordinator], SwitchE
 
     async def _set_activated(self, activated: bool) -> None:
         """Set the timer activation state, preserving all other fields."""
-        all_timers = list(
-            self.coordinator.data.get("climate_timers", {}).get(self._vin) or []
-        )
+        all_timers = list(self.coordinator.data.get("climate_timers", {}).get(self._vin) or [])
 
         # Modify the target timer's activated field
         found = False

--- a/custom_components/polestar_soc/switch.py
+++ b/custom_components/polestar_soc/switch.py
@@ -280,7 +280,7 @@ class PolestarClimateTimerSwitch(CoordinatorEntity[PolestarCoordinator], SwitchE
                 break
 
         if not found:
-            raise HomeAssistantError(f"Climate timer {self._slot} not found")
+            raise HomeAssistantError(f"Climate timer {self._slot + 1} not found")
 
         try:
             await self.hass.async_add_executor_job(
@@ -290,6 +290,6 @@ class PolestarClimateTimerSwitch(CoordinatorEntity[PolestarCoordinator], SwitchE
             )
         except (grpc.RpcError, PccsError) as err:
             raise HomeAssistantError(
-                f"Failed to set climate timer {self._slot}: {err}"
+                f"Failed to set climate timer {self._slot + 1}: {err}"
             ) from err
         await self.coordinator.async_request_refresh()

--- a/custom_components/polestar_soc/switch.py
+++ b/custom_components/polestar_soc/switch.py
@@ -39,6 +39,8 @@ async def async_setup_entry(
         vin = vehicle["vin"]
         entities.append(PolestarChargeTimerSwitch(coordinator, vehicle, vin))
         entities.append(PolestarClimateSwitch(coordinator, vehicle, vin))
+        for slot in range(5):
+            entities.append(PolestarClimateTimerSwitch(coordinator, vehicle, vin, slot))
 
     async_add_entities(entities)
 
@@ -185,4 +187,109 @@ class PolestarClimateSwitch(CoordinatorEntity[PolestarCoordinator], SwitchEntity
             )
         except (grpc.RpcError, PccsError) as err:
             raise HomeAssistantError(f"Failed to stop climate: {err}") from err
+        await self.coordinator.async_request_refresh()
+
+
+class PolestarClimateTimerSwitch(CoordinatorEntity[PolestarCoordinator], SwitchEntity):
+    """Parking climate timer switch — enables or disables a scheduled climate timer."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:radiator"
+
+    def __init__(
+        self,
+        coordinator: PolestarCoordinator,
+        vehicle: dict,
+        vin: str,
+        slot: int,
+    ) -> None:
+        """Initialize the climate timer switch entity.
+
+        Args:
+            slot: Timer slot index (0-4, matching the API's 0-based index field).
+        """
+        super().__init__(coordinator)
+        self._vin = vin
+        self._slot = slot
+        display_num = slot + 1  # 1-based for user display
+        self._attr_translation_key = f"climate_timer_{display_num}"
+        self._attr_unique_id = f"{vin}_climate_timer_{display_num}"
+
+        if display_num >= 3:
+            self._attr_entity_registry_enabled_default = False
+
+        model_name = "Polestar"
+        content = vehicle.get("content")
+        if content and content.get("model"):
+            model_name = content["model"].get("name", model_name)
+        year = vehicle.get("modelYear", "")
+        device_name = f"{model_name} ({year})" if year else model_name
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vin)},
+            name=device_name,
+            manufacturer="Polestar",
+            model=model_name,
+            sw_version=str(year) if year else None,
+        )
+
+    def _get_timer(self) -> dict | None:
+        """Get the timer dict for this slot from coordinator data."""
+        data = self.coordinator.data
+        if not data:
+            return None
+        timers = data.get("climate_timers", {}).get(self._vin) or []
+        for timer in timers:
+            if timer.get("index") == self._slot:
+                return timer
+        return None
+
+    @property
+    def available(self) -> bool:
+        """Return False when the timer slot is empty."""
+        return super().available and self._get_timer() is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether this climate timer is active."""
+        timer = self._get_timer()
+        if timer is None:
+            return None
+        return timer.get("activated")
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable this climate timer."""
+        await self._set_activated(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable this climate timer."""
+        await self._set_activated(False)
+
+    async def _set_activated(self, activated: bool) -> None:
+        """Set the timer activation state, preserving all other fields."""
+        all_timers = list(
+            self.coordinator.data.get("climate_timers", {}).get(self._vin) or []
+        )
+
+        # Modify the target timer's activated field
+        found = False
+        for i, timer in enumerate(all_timers):
+            if timer.get("index") == self._slot:
+                all_timers[i] = {**timer, "activated": activated}
+                found = True
+                break
+
+        if not found:
+            raise HomeAssistantError(f"Climate timer {self._slot} not found")
+
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.pccs.set_parking_climate_timers,
+                self._vin,
+                all_timers,
+            )
+        except (grpc.RpcError, PccsError) as err:
+            raise HomeAssistantError(
+                f"Failed to set climate timer {self._slot}: {err}"
+            ) from err
         await self.coordinator.async_request_refresh()

--- a/custom_components/polestar_soc/time.py
+++ b/custom_components/polestar_soc/time.py
@@ -207,9 +207,7 @@ class PolestarClimateTimerTimeEntity(CoordinatorEntity[PolestarCoordinator], Tim
 
         Sends the full timer list (replace-all semantics).
         """
-        all_timers = list(
-            self.coordinator.data.get("climate_timers", {}).get(self._vin) or []
-        )
+        all_timers = list(self.coordinator.data.get("climate_timers", {}).get(self._vin) or [])
 
         # Modify the target timer's departure time
         found = False

--- a/custom_components/polestar_soc/time.py
+++ b/custom_components/polestar_soc/time.py
@@ -29,11 +29,13 @@ async def async_setup_entry(
     """Set up Polestar time entities from a config entry."""
     coordinator: PolestarCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    entities: list[PolestarChargeTimeEntity] = []
+    entities: list[TimeEntity] = []
     for vehicle in coordinator.data.get("vehicles", []):
         vin = vehicle["vin"]
         entities.append(PolestarChargeTimeEntity(coordinator, vehicle, vin, time_key="start"))
         entities.append(PolestarChargeTimeEntity(coordinator, vehicle, vin, time_key="end"))
+        for slot in range(5):
+            entities.append(PolestarClimateTimerTimeEntity(coordinator, vehicle, vin, slot))
 
     async_add_entities(entities)
 
@@ -127,4 +129,107 @@ class PolestarChargeTimeEntity(CoordinatorEntity[PolestarCoordinator], TimeEntit
             )
         except (grpc.RpcError, PccsError) as err:
             raise HomeAssistantError(f"Failed to set charge timer: {err}") from err
+        await self.coordinator.async_request_refresh()
+
+
+class PolestarClimateTimerTimeEntity(CoordinatorEntity[PolestarCoordinator], TimeEntity):
+    """Climate timer departure time entity — sets when the car should be ready."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: PolestarCoordinator,
+        vehicle: dict,
+        vin: str,
+        slot: int,
+    ) -> None:
+        """Initialize the climate timer time entity.
+
+        Args:
+            slot: Timer slot index (0-4, matching the API's 0-based index field).
+        """
+        super().__init__(coordinator)
+        self._vin = vin
+        self._slot = slot
+        display_num = slot + 1  # 1-based for user display
+        self._attr_translation_key = f"climate_timer_{display_num}_time"
+        self._attr_unique_id = f"{vin}_climate_timer_{display_num}_time"
+
+        if display_num >= 3:
+            self._attr_entity_registry_enabled_default = False
+
+        model_name = "Polestar"
+        content = vehicle.get("content")
+        if content and content.get("model"):
+            model_name = content["model"].get("name", model_name)
+        year = vehicle.get("modelYear", "")
+        device_name = f"{model_name} ({year})" if year else model_name
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vin)},
+            name=device_name,
+            manufacturer="Polestar",
+            model=model_name,
+            sw_version=str(year) if year else None,
+        )
+
+    def _get_timer(self) -> dict | None:
+        """Get the timer dict for this slot from coordinator data."""
+        data = self.coordinator.data
+        if not data:
+            return None
+        timers = data.get("climate_timers", {}).get(self._vin) or []
+        for timer in timers:
+            if timer.get("index") == self._slot:
+                return timer
+        return None
+
+    @property
+    def available(self) -> bool:
+        """Return False when the timer slot is empty."""
+        return super().available and self._get_timer() is not None
+
+    @property
+    def native_value(self) -> time | None:
+        """Return the departure time for this timer."""
+        timer = self._get_timer()
+        if timer is None:
+            return None
+        hour = timer.get("hour")
+        minute = timer.get("minute")
+        if hour is None or minute is None:
+            return None
+        return time(hour=hour, minute=minute)
+
+    async def async_set_value(self, value: time) -> None:
+        """Set the climate timer departure time via PCCS.
+
+        Sends the full timer list (replace-all semantics).
+        """
+        all_timers = list(
+            self.coordinator.data.get("climate_timers", {}).get(self._vin) or []
+        )
+
+        # Modify the target timer's departure time
+        found = False
+        for i, timer in enumerate(all_timers):
+            if timer.get("index") == self._slot:
+                all_timers[i] = {**timer, "hour": value.hour, "minute": value.minute}
+                found = True
+                break
+
+        if not found:
+            raise HomeAssistantError(f"Climate timer {self._slot} not found")
+
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.pccs.set_parking_climate_timers,
+                self._vin,
+                all_timers,
+            )
+        except (grpc.RpcError, PccsError) as err:
+            raise HomeAssistantError(
+                f"Failed to set climate timer {self._slot} time: {err}"
+            ) from err
         await self.coordinator.async_request_refresh()

--- a/custom_components/polestar_soc/time.py
+++ b/custom_components/polestar_soc/time.py
@@ -220,7 +220,7 @@ class PolestarClimateTimerTimeEntity(CoordinatorEntity[PolestarCoordinator], Tim
                 break
 
         if not found:
-            raise HomeAssistantError(f"Climate timer {self._slot} not found")
+            raise HomeAssistantError(f"Climate timer {self._slot + 1} not found")
 
         try:
             await self.hass.async_add_executor_job(
@@ -230,6 +230,6 @@ class PolestarClimateTimerTimeEntity(CoordinatorEntity[PolestarCoordinator], Tim
             )
         except (grpc.RpcError, PccsError) as err:
             raise HomeAssistantError(
-                f"Failed to set climate timer {self._slot} time: {err}"
+                f"Failed to set climate timer {self._slot + 1} time: {err}"
             ) from err
         await self.coordinator.async_request_refresh()

--- a/custom_components/polestar_soc/translations/en.json
+++ b/custom_components/polestar_soc/translations/en.json
@@ -81,6 +81,9 @@
     "number": {
       "charge_limit": {
         "name": "Charge limit"
+      },
+      "climate_timer_temperature": {
+        "name": "Climate timer temperature"
       }
     },
     "time": {
@@ -89,6 +92,21 @@
       },
       "charging_end_time": {
         "name": "Charging end time"
+      },
+      "climate_timer_1_time": {
+        "name": "Climate timer 1 time"
+      },
+      "climate_timer_2_time": {
+        "name": "Climate timer 2 time"
+      },
+      "climate_timer_3_time": {
+        "name": "Climate timer 3 time"
+      },
+      "climate_timer_4_time": {
+        "name": "Climate timer 4 time"
+      },
+      "climate_timer_5_time": {
+        "name": "Climate timer 5 time"
       }
     },
     "switch": {
@@ -97,6 +115,21 @@
       },
       "climate": {
         "name": "Climate"
+      },
+      "climate_timer_1": {
+        "name": "Climate timer 1"
+      },
+      "climate_timer_2": {
+        "name": "Climate timer 2"
+      },
+      "climate_timer_3": {
+        "name": "Climate timer 3"
+      },
+      "climate_timer_4": {
+        "name": "Climate timer 4"
+      },
+      "climate_timer_5": {
+        "name": "Climate timer 5"
       }
     },
     "lock": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,43 @@ def sample_charge_timer():
 
 
 @pytest.fixture
+def sample_climate_timers():
+    """Return a sample list of parking climate timer dicts."""
+    return [
+        {
+            "timer_id": "aaaaaaaa-1111-2222-3333-444444444444",
+            "index": 0,
+            "hour": 7,
+            "minute": 30,
+            "activated": True,
+            "repeat": True,
+            "weekdays": [1, 2, 3, 4, 5],
+            "metadata_raw": None,
+            "start_date_raw": None,
+        },
+        {
+            "timer_id": "bbbbbbbb-1111-2222-3333-444444444444",
+            "index": 1,
+            "hour": 8,
+            "minute": 0,
+            "activated": False,
+            "repeat": False,
+            "weekdays": [],
+            "metadata_raw": None,
+            "start_date_raw": None,
+        },
+    ]
+
+
+@pytest.fixture
+def sample_climate_timer_settings():
+    """Return a sample climate timer settings dict."""
+    return {
+        "temperature": 22.0,
+    }
+
+
+@pytest.fixture
 def sample_availability():
     """Return a sample availability state dict (as returned by CepClient)."""
     return {
@@ -145,6 +182,8 @@ def sample_coordinator_data(
         "odometer": {vin: sample_odometer},
         "target_soc": {},
         "charge_timer": {},
+        "climate_timers": {},
+        "climate_timer_settings": {},
         "climate": {vin: sample_climate},
         "cep_battery": {vin: sample_cep_battery},
         "location": {vin: sample_location},

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -947,9 +947,7 @@ class TestParseClimateTimersResponse:
     def test_metadata_and_start_date_preserved(self):
         metadata = _encode_field_varint(1, 12345)
         start_date = (
-            _encode_field_varint(1, 2026)
-            + _encode_field_varint(2, 3)
-            + _encode_field_varint(3, 15)
+            _encode_field_varint(1, 2026) + _encode_field_varint(2, 3) + _encode_field_varint(3, 15)
         )
         timer = (
             _encode_field_bytes(1, b"uuid-1")
@@ -1098,9 +1096,17 @@ class TestBuildParkingClimateTimer:
 class TestBuildSetClimateTimersRequest:
     def test_structure(self):
         timers = [
-            {"timer_id": "uuid-1", "index": 1, "hour": 7, "minute": 30,
-             "activated": True, "repeat": False, "weekdays": [],
-             "metadata_raw": None, "start_date_raw": None},
+            {
+                "timer_id": "uuid-1",
+                "index": 1,
+                "hour": 7,
+                "minute": 30,
+                "activated": True,
+                "repeat": False,
+                "weekdays": [],
+                "metadata_raw": None,
+                "start_date_raw": None,
+            },
         ]
         data = _build_set_climate_timers_request("TESTVIN123", timers)
         fields = _decode_message(data)
@@ -1114,12 +1120,28 @@ class TestBuildSetClimateTimersRequest:
 
     def test_multiple_timers(self):
         timers = [
-            {"timer_id": "uuid-1", "index": 1, "hour": 7, "minute": 0,
-             "activated": True, "repeat": False, "weekdays": [],
-             "metadata_raw": None, "start_date_raw": None},
-            {"timer_id": "uuid-2", "index": 2, "hour": 8, "minute": 0,
-             "activated": False, "repeat": False, "weekdays": [],
-             "metadata_raw": None, "start_date_raw": None},
+            {
+                "timer_id": "uuid-1",
+                "index": 1,
+                "hour": 7,
+                "minute": 0,
+                "activated": True,
+                "repeat": False,
+                "weekdays": [],
+                "metadata_raw": None,
+                "start_date_raw": None,
+            },
+            {
+                "timer_id": "uuid-2",
+                "index": 2,
+                "hour": 8,
+                "minute": 0,
+                "activated": False,
+                "repeat": False,
+                "weekdays": [],
+                "metadata_raw": None,
+                "start_date_raw": None,
+            },
         ]
         data = _build_set_climate_timers_request("TESTVIN123", timers)
         fields = _decode_message(data)

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -8,9 +8,13 @@ from custom_components.polestar_soc.pccs import (
     _METHOD_CLIMATIZATION_START,
     _METHOD_CLIMATIZATION_STOP,
     _METHOD_GET_CHARGE_TIMER,
+    _METHOD_GET_CLIMATE_TIMER_SETTINGS,
+    _METHOD_GET_CLIMATE_TIMERS,
     _METHOD_GET_TARGET_SOC,
     _METHOD_LOCK,
     _METHOD_SET_CHARGE_TIMER,
+    _METHOD_SET_CLIMATE_TIMER_SETTINGS,
+    _METHOD_SET_CLIMATE_TIMERS,
     _METHOD_SET_TARGET_SOC,
     _METHOD_UNLOCK,
     PccsClient,
@@ -18,24 +22,34 @@ from custom_components.polestar_soc.pccs import (
     _build_climatization_stop_request,
     _build_invocation_request,
     _build_lock_request,
+    _build_parking_climate_timer,
     _build_set_charge_timer_request,
+    _build_set_climate_timer_settings_request,
+    _build_set_climate_timers_request,
     _build_set_target_soc_request,
     _build_time_of_day,
     _build_unlock_request,
     _lock_error_context,
     _parse_charge_timer_response,
+    _parse_climate_timer_settings_response,
+    _parse_climate_timers_response,
     _parse_set_charge_timer_response,
+    _parse_set_climate_timers_response,
     _parse_target_soc_response,
 )
 from custom_components.polestar_soc.proto import (
     _decode_message,
+    _decode_packed_varints,
     _decode_varint,
     _encode_field_bytes,
     _encode_field_fixed32,
     _encode_field_varint,
+    _encode_packed_varints,
     _encode_varint,
     _get_bool,
+    _get_float,
     _get_int,
+    _get_string,
     _get_submessage,
     _parse_invocation_response,
 )
@@ -744,3 +758,393 @@ class TestLockErrorContext:
         inner = _encode_field_varint(3, 11)
         data = _encode_field_bytes(1, inner) + _encode_field_varint(2, 99)
         assert _lock_error_context(data) == "lock error (code 99)"
+
+
+# ---------------------------------------------------------------------------
+# Proto helpers: _get_string, _get_float, packed varints
+# ---------------------------------------------------------------------------
+
+
+class TestGetString:
+    def test_existing_field(self):
+        fields = {1: [b"hello"]}
+        assert _get_string(fields, 1) == "hello"
+
+    def test_missing_field_default(self):
+        assert _get_string({}, 1) == ""
+        assert _get_string({}, 1, "default") == "default"
+
+    def test_non_bytes_returns_default(self):
+        fields = {1: [42]}
+        assert _get_string(fields, 1) == ""
+
+    def test_utf8_decoding(self):
+        fields = {1: ["Ström".encode()]}
+        assert _get_string(fields, 1) == "Ström"
+
+
+class TestGetFloat:
+    def test_existing_field(self):
+        # Encode 22.0 as fixed32, then decode and extract
+        data = _encode_field_fixed32(3, 22.0)
+        fields = _decode_message(data)
+        assert _get_float(fields, 3) == pytest.approx(22.0)
+
+    def test_missing_field(self):
+        assert _get_float({}, 3) is None
+
+    def test_non_int_returns_none(self):
+        fields = {3: [b"not-a-float"]}
+        assert _get_float(fields, 3) is None
+
+    def test_negative_temperature(self):
+        data = _encode_field_fixed32(3, -5.0)
+        fields = _decode_message(data)
+        assert _get_float(fields, 3) == pytest.approx(-5.0)
+
+    def test_fractional(self):
+        data = _encode_field_fixed32(3, 18.5)
+        fields = _decode_message(data)
+        assert _get_float(fields, 3) == pytest.approx(18.5)
+
+
+class TestPackedVarints:
+    def test_decode_empty(self):
+        assert _decode_packed_varints(b"") == []
+
+    def test_decode_single_value(self):
+        encoded = _encode_varint(5)
+        assert _decode_packed_varints(encoded) == [5]
+
+    def test_decode_multiple_values(self):
+        encoded = _encode_varint(1) + _encode_varint(3) + _encode_varint(5)
+        assert _decode_packed_varints(encoded) == [1, 3, 5]
+
+    def test_encode_empty(self):
+        assert _encode_packed_varints(6, []) == b""
+
+    def test_roundtrip(self):
+        values = [1, 2, 3, 4, 5]
+        encoded = _encode_packed_varints(6, values)
+        fields = _decode_message(encoded)
+        raw = fields[6][0]
+        assert isinstance(raw, bytes)
+        assert _decode_packed_varints(raw) == values
+
+    def test_roundtrip_large_values(self):
+        values = [128, 300, 16384]
+        encoded = _encode_packed_varints(6, values)
+        fields = _decode_message(encoded)
+        raw = fields[6][0]
+        assert _decode_packed_varints(raw) == values
+
+
+# ---------------------------------------------------------------------------
+# Climate timer service paths
+# ---------------------------------------------------------------------------
+
+
+class TestClimateTimerServicePaths:
+    def test_get_timers_path(self):
+        svc = "/pccs.chronos.services.v1.ParkingClimateTimerService"
+        assert f"{svc}/GetTimers" == _METHOD_GET_CLIMATE_TIMERS
+
+    def test_set_timers_path(self):
+        svc = "/pccs.chronos.services.v1.ParkingClimateTimerService"
+        assert f"{svc}/SetTimers" == _METHOD_SET_CLIMATE_TIMERS
+
+    def test_get_settings_path(self):
+        svc = "/pccs.chronos.services.v1.ParkingClimateTimerService"
+        assert f"{svc}/GetTimerSettings" == _METHOD_GET_CLIMATE_TIMER_SETTINGS
+
+    def test_set_settings_path(self):
+        svc = "/pccs.chronos.services.v1.ParkingClimateTimerService"
+        assert f"{svc}/SetTimerSettings" == _METHOD_SET_CLIMATE_TIMER_SETTINGS
+
+
+# ---------------------------------------------------------------------------
+# Climate timer response parsers
+# ---------------------------------------------------------------------------
+
+
+class TestParseClimateTimersResponse:
+    def test_empty_data(self):
+        assert _parse_climate_timers_response(b"") == []
+
+    def test_single_timer(self):
+        # Build a single ParkingClimateTimer
+        ready_at = _build_time_of_day(7, 30)
+        timer = (
+            _encode_field_bytes(1, b"timer-uuid-1")
+            + _encode_field_varint(2, 1)  # index
+            + _encode_field_bytes(3, ready_at)
+            + _encode_field_varint(4, 1)  # activated=True
+        )
+        # Wrap in response: field 3 = repeated timers (baseline)
+        data = _encode_field_bytes(3, timer)
+        result = _parse_climate_timers_response(data)
+        assert len(result) == 1
+        assert result[0]["timer_id"] == "timer-uuid-1"
+        assert result[0]["index"] == 1
+        assert result[0]["hour"] == 7
+        assert result[0]["minute"] == 30
+        assert result[0]["activated"] is True
+
+    def test_multiple_timers(self):
+        timer1 = (
+            _encode_field_bytes(1, b"uuid-1")
+            + _encode_field_varint(2, 1)
+            + _encode_field_bytes(3, _build_time_of_day(7, 0))
+            + _encode_field_varint(4, 1)
+        )
+        timer2 = (
+            _encode_field_bytes(1, b"uuid-2")
+            + _encode_field_varint(2, 2)
+            + _encode_field_bytes(3, _build_time_of_day(8, 15))
+        )
+        data = _encode_field_bytes(3, timer1) + _encode_field_bytes(3, timer2)
+        result = _parse_climate_timers_response(data)
+        assert len(result) == 2
+        assert result[0]["index"] == 1
+        assert result[1]["index"] == 2
+        assert result[1]["hour"] == 8
+        assert result[1]["minute"] == 15
+        assert result[1]["activated"] is False
+
+    def test_pending_preferred_over_baseline(self):
+        baseline_timer = (
+            _encode_field_bytes(1, b"uuid-1")
+            + _encode_field_varint(2, 1)
+            + _encode_field_bytes(3, _build_time_of_day(7, 0))
+        )
+        pending_timer = (
+            _encode_field_bytes(1, b"uuid-1")
+            + _encode_field_varint(2, 1)
+            + _encode_field_bytes(3, _build_time_of_day(9, 45))
+            + _encode_field_varint(4, 1)
+        )
+        data = _encode_field_bytes(3, baseline_timer) + _encode_field_bytes(4, pending_timer)
+        result = _parse_climate_timers_response(data)
+        assert len(result) == 1
+        assert result[0]["hour"] == 9
+        assert result[0]["minute"] == 45
+        assert result[0]["activated"] is True
+
+    def test_weekdays_parsed(self):
+        weekdays = _encode_varint(1) + _encode_varint(3) + _encode_varint(5)
+        timer = (
+            _encode_field_bytes(1, b"uuid-1")
+            + _encode_field_varint(2, 1)
+            + _encode_field_bytes(3, _build_time_of_day(7, 0))
+            + _encode_field_varint(5, 1)  # repeat=True
+            + _encode_field_bytes(6, weekdays)  # packed weekdays
+        )
+        data = _encode_field_bytes(3, timer)
+        result = _parse_climate_timers_response(data)
+        assert result[0]["repeat"] is True
+        assert result[0]["weekdays"] == [1, 3, 5]
+
+    def test_metadata_and_start_date_preserved(self):
+        metadata = _encode_field_varint(1, 12345)
+        start_date = (
+            _encode_field_varint(1, 2026)
+            + _encode_field_varint(2, 3)
+            + _encode_field_varint(3, 15)
+        )
+        timer = (
+            _encode_field_bytes(1, b"uuid-1")
+            + _encode_field_varint(2, 1)
+            + _encode_field_bytes(3, _build_time_of_day(7, 0))
+            + _encode_field_bytes(7, metadata)
+            + _encode_field_bytes(8, start_date)
+        )
+        data = _encode_field_bytes(3, timer)
+        result = _parse_climate_timers_response(data)
+        assert result[0]["metadata_raw"] == metadata
+        assert result[0]["start_date_raw"] == start_date
+
+
+class TestParseClimateTimerSettingsResponse:
+    def test_empty_data(self):
+        result = _parse_climate_timer_settings_response(b"")
+        assert result["temperature"] is None
+
+    def test_with_temperature(self):
+        # TimerSettings: field 3 = temperature (fixed32)
+        settings = _encode_field_fixed32(3, 22.0) + _encode_field_varint(4, 1)
+        # Response: field 1 = baseline settings
+        data = _encode_field_bytes(1, settings)
+        result = _parse_climate_timer_settings_response(data)
+        assert result["temperature"] == pytest.approx(22.0)
+
+    def test_pending_preferred(self):
+        baseline = _encode_field_fixed32(3, 20.0)
+        pending = _encode_field_fixed32(3, 25.0)
+        data = _encode_field_bytes(1, baseline) + _encode_field_bytes(2, pending)
+        result = _parse_climate_timer_settings_response(data)
+        assert result["temperature"] == pytest.approx(25.0)
+
+    def test_no_settings_in_envelope(self):
+        # Only updatedAt field
+        data = _encode_field_varint(3, 1773247754487)
+        result = _parse_climate_timer_settings_response(data)
+        assert result["temperature"] is None
+
+
+class TestParseSetClimateTimersResponse:
+    def test_empty_data(self):
+        result = _parse_set_climate_timers_response(b"")
+        assert result["id"] == ""
+        assert result["vin"] == ""
+        assert result["status"] == 0
+        assert result["message"] == ""
+
+    def test_success(self):
+        data = (
+            _encode_field_bytes(1, b"req-uuid")
+            + _encode_field_bytes(2, b"TESTVIN123")
+            + _encode_field_varint(3, 1)  # SUCCESS
+        )
+        result = _parse_set_climate_timers_response(data)
+        assert result["id"] == "req-uuid"
+        assert result["vin"] == "TESTVIN123"
+        assert result["status"] == 1
+        assert result["message"] == ""
+
+    def test_validation_error(self):
+        data = (
+            _encode_field_bytes(1, b"req-uuid")
+            + _encode_field_bytes(2, b"TESTVIN123")
+            + _encode_field_varint(3, 2)  # VALIDATION_ERROR
+            + _encode_field_bytes(4, b"Invalid timer data")
+        )
+        result = _parse_set_climate_timers_response(data)
+        assert result["status"] == 2
+        assert result["message"] == "Invalid timer data"
+
+
+# ---------------------------------------------------------------------------
+# Climate timer request builders
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParkingClimateTimer:
+    def test_basic_timer(self):
+        timer = {
+            "timer_id": "test-uuid",
+            "index": 1,
+            "hour": 7,
+            "minute": 30,
+            "activated": True,
+            "repeat": True,
+            "weekdays": [1, 3, 5],
+            "metadata_raw": None,
+            "start_date_raw": None,
+        }
+        data = _build_parking_climate_timer(timer)
+        fields = _decode_message(data)
+        assert fields[1] == [b"test-uuid"]
+        assert fields[2] == [1]
+        # Field 3 = DailyTime sub-message
+        ready_at = _get_submessage(fields, 3)
+        assert _get_int(ready_at, 1) == 7
+        assert _get_int(ready_at, 2) == 30
+        # Field 4 = activated
+        assert _get_bool(fields, 4) is True
+        # Field 5 = repeat
+        assert _get_bool(fields, 5) is True
+        # Field 6 = weekdays (packed)
+        raw_weekdays = fields[6][0]
+        assert _decode_packed_varints(raw_weekdays) == [1, 3, 5]
+
+    def test_inactive_timer(self):
+        timer = {
+            "timer_id": "test-uuid",
+            "index": 2,
+            "hour": 8,
+            "minute": 0,
+            "activated": False,
+            "repeat": False,
+            "weekdays": [],
+            "metadata_raw": None,
+            "start_date_raw": None,
+        }
+        data = _build_parking_climate_timer(timer)
+        fields = _decode_message(data)
+        # activated and repeat should be omitted (proto3 default false)
+        assert 4 not in fields
+        assert 5 not in fields
+        # No weekdays
+        assert 6 not in fields
+
+    def test_metadata_passthrough(self):
+        metadata = _encode_field_varint(1, 99)
+        timer = {
+            "timer_id": "test-uuid",
+            "index": 1,
+            "hour": 7,
+            "minute": 0,
+            "activated": True,
+            "repeat": False,
+            "weekdays": [],
+            "metadata_raw": metadata,
+            "start_date_raw": None,
+        }
+        data = _build_parking_climate_timer(timer)
+        fields = _decode_message(data)
+        assert fields[7] == [metadata]
+
+
+class TestBuildSetClimateTimersRequest:
+    def test_structure(self):
+        timers = [
+            {"timer_id": "uuid-1", "index": 1, "hour": 7, "minute": 30,
+             "activated": True, "repeat": False, "weekdays": [],
+             "metadata_raw": None, "start_date_raw": None},
+        ]
+        data = _build_set_climate_timers_request("TESTVIN123", timers)
+        fields = _decode_message(data)
+        # Field 1: ChronosRequest
+        chronos = _decode_message(fields[1][0])
+        assert chronos[2] == [b"TESTVIN123"]
+        # Field 2: repeated ParkingClimateTimer (at least one)
+        assert 2 in fields
+        timer_fields = _decode_message(fields[2][0])
+        assert timer_fields[1] == [b"uuid-1"]
+
+    def test_multiple_timers(self):
+        timers = [
+            {"timer_id": "uuid-1", "index": 1, "hour": 7, "minute": 0,
+             "activated": True, "repeat": False, "weekdays": [],
+             "metadata_raw": None, "start_date_raw": None},
+            {"timer_id": "uuid-2", "index": 2, "hour": 8, "minute": 0,
+             "activated": False, "repeat": False, "weekdays": [],
+             "metadata_raw": None, "start_date_raw": None},
+        ]
+        data = _build_set_climate_timers_request("TESTVIN123", timers)
+        fields = _decode_message(data)
+        # Both timers in field 2
+        assert len(fields[2]) == 2
+
+
+class TestBuildSetClimateTimerSettingsRequest:
+    def test_roundtrip(self):
+        data = _build_set_climate_timer_settings_request("TESTVIN123", 22.0)
+        fields = _decode_message(data)
+        # Field 1: ChronosRequest
+        chronos = _decode_message(fields[1][0])
+        assert chronos[2] == [b"TESTVIN123"]
+        # Field 2: TimerSettings sub-message
+        settings = _get_submessage(fields, 2)
+        assert settings is not None
+        # Field 3 = temperature (fixed32)
+        temp = _get_float(settings, 3)
+        assert temp == pytest.approx(22.0)
+        # Field 4 = is_compartment_temperature_requested (bool)
+        assert _get_bool(settings, 4) is True
+
+    def test_fractional_temperature(self):
+        data = _build_set_climate_timer_settings_request("TESTVIN123", 18.5)
+        fields = _decode_message(data)
+        settings = _get_submessage(fields, 2)
+        assert _get_float(settings, 3) == pytest.approx(18.5)


### PR DESCRIPTION
## Summary
- Add support for reading and controlling **parking climate timers** via the PCCS `ParkingClimateTimerService` gRPC API
- Expose up to 5 individual timer schedules as **switch** (activate/deactivate) and **time** (departure time) entities
- Expose shared **climate timer temperature** as a number entity (15–28°C, 0.5° step)
- Timer slots 3–5 are disabled by default in the entity registry to keep the UI clean

## Details

**New entities per vehicle:**
| Entity | Type | Description |
|--------|------|-------------|
| Climate timer 1–5 | Switch | Enable/disable each timer |
| Climate timer 1–5 time | Time | Set departure time per timer |
| Climate timer temperature | Number | Shared target cabin temperature |

**Key implementation notes:**
- Fixed 5 timer slots with `available` property returning `False` for empty slots
- SetTimers uses replace-all semantics: reads all timers, modifies the target, sends the full list
- All timer fields (weekdays, metadata, start_date) are preserved during round-tripping
- SetTimerSettings is the first `unary_unary` RPC in the codebase (all others are `unary_stream`)
- Timer settings (GetTimerSettings) returns UNIMPLEMENTED on some older models — handled gracefully via coordinator try/except
- Timer indices are 0-based from the API, displayed as 1-based to users

**Files changed:**
- `proto.py` — `_get_string`, `_get_float`, `_decode_packed_varints`, `_encode_packed_varints`
- `pccs.py` — 4 service paths, 3 builders, 3 parsers, 4 PccsClient methods
- `coordinator.py` — fetches `climate_timers` and `climate_timer_settings` per VIN
- `switch.py` — `PolestarClimateTimerSwitch`
- `time.py` — `PolestarClimateTimerTimeEntity`
- `number.py` — `PolestarClimateTimerTemperatureNumber`
- `const.py` — `WEEKDAY_MAP`
- `strings.json` + `translations/en.json` — 11 new entity translation keys

## Test plan
- [x] 295 unit tests passing
- [x] Ruff lint clean
- [x] Live-tested GetTimers and SetTimers against real vehicle API
- [x] Verified timer read/write round-trip preserves all fields
- [ ] Verify entities appear correctly in HA dashboard
- [ ] Test toggle and time change from HA UI