### PR TITLE
Add charging amp limit number entity

### DIFF
--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -519,6 +519,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
                     "battery": {},
                     "odometer": {},
                     "target_soc": {},
+                    "amp_limit": {},
                     "charge_timer": {},
                     "climate_timers": {},
                     "climate_timer_settings": {},
@@ -544,6 +545,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
 
             # Fetch PCCS data (charge target + timer + climate timers) per VIN
             target_soc_by_vin: dict = {}
+            amp_limit_by_vin: dict = {}
             charge_timer_by_vin: dict = {}
             climate_timers_by_vin: dict = {}
             climate_timer_settings_by_vin: dict = {}
@@ -552,6 +554,10 @@ class PolestarCoordinator(DataUpdateCoordinator):
                     target_soc_by_vin[vin] = self.pccs.get_target_soc(vin)
                 except Exception:
                     _LOGGER.debug("Failed to fetch PCCS target SOC for %s", vin)
+                try:
+                    amp_limit_by_vin[vin] = self.pccs.get_amp_limit(vin)
+                except Exception:
+                    _LOGGER.debug("Failed to fetch PCCS amp limit for %s", vin)
                 try:
                     charge_timer_by_vin[vin] = self.pccs.get_global_charge_timer(vin)
                 except Exception:
@@ -600,6 +606,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 "battery": battery_by_vin,
                 "odometer": odometer_by_vin,
                 "target_soc": target_soc_by_vin,
+                "amp_limit": amp_limit_by_vin,
                 "charge_timer": charge_timer_by_vin,
                 "climate_timers": climate_timers_by_vin,
                 "climate_timer_settings": climate_timer_settings_by_vin,

--- a/custom_components/polestar_soc/number.py
+++ b/custom_components/polestar_soc/number.py
@@ -7,7 +7,7 @@ import logging
 import grpc
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.const import PERCENTAGE, UnitOfElectricCurrent, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -33,6 +33,7 @@ async def async_setup_entry(
     for vehicle in coordinator.data.get("vehicles", []):
         vin = vehicle["vin"]
         entities.append(PolestarChargeLimitNumber(coordinator, vehicle, vin))
+        entities.append(PolestarAmpLimitNumber(coordinator, vehicle, vin))
         entities.append(PolestarClimateTimerTemperatureNumber(coordinator, vehicle, vin))
 
     async_add_entities(entities)
@@ -95,6 +96,66 @@ class PolestarChargeLimitNumber(CoordinatorEntity[PolestarCoordinator], NumberEn
             )
         except grpc.RpcError as err:
             raise HomeAssistantError(f"Failed to set charge limit: {err}") from err
+        await self.coordinator.async_request_refresh()
+
+
+class PolestarAmpLimitNumber(CoordinatorEntity[PolestarCoordinator], NumberEntity):
+    """Charging amp limit — sets the maximum AC charging current in amps."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "amp_limit"
+    _attr_native_min_value = 6
+    _attr_native_max_value = 32
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+    _attr_device_class = NumberDeviceClass.CURRENT
+    _attr_mode = NumberMode.SLIDER
+
+    def __init__(
+        self,
+        coordinator: PolestarCoordinator,
+        vehicle: dict,
+        vin: str,
+    ) -> None:
+        """Initialize the amp limit number entity."""
+        super().__init__(coordinator)
+        self._vin = vin
+        self._attr_unique_id = f"{vin}_amp_limit"
+
+        model_name = "Polestar"
+        content = vehicle.get("content")
+        if content and content.get("model"):
+            model_name = content["model"].get("name", model_name)
+        year = vehicle.get("modelYear", "")
+        device_name = f"{model_name} ({year})" if year else model_name
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vin)},
+            name=device_name,
+            manufacturer="Polestar",
+            model=model_name,
+            sw_version=str(year) if year else None,
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current charging amp limit."""
+        data = self.coordinator.data
+        if not data:
+            return None
+        amp_data = data.get("amp_limit", {}).get(self._vin)
+        if amp_data is None:
+            return None
+        return amp_data.get("pending_amp_limit") or amp_data.get("amp_limit")
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the charging amp limit via PCCS."""
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.pccs.set_amp_limit, self._vin, int(value)
+            )
+        except (grpc.RpcError, PccsError) as err:
+            raise HomeAssistantError(f"Failed to set amp limit: {err}") from err
         await self.coordinator.async_request_refresh()
 
 

--- a/custom_components/polestar_soc/pccs.py
+++ b/custom_components/polestar_soc/pccs.py
@@ -55,8 +55,11 @@ class PccsError(HomeAssistantError):
 _SVC_TARGET_SOC = "/pccs.chronos.services.v1.TargetSocService"
 _SVC_CHARGE_TIMER = "/pccs.chronos.services.v2.GlobalChargeTimerService"
 _SVC_CLIMATE_TIMER = "/pccs.chronos.services.v1.ParkingClimateTimerService"
+_SVC_AMP_LIMIT = "/pccs.chronos.services.v1.AmpLimitService"
 _SVC_INVOCATION = "/pccs.invocation.v1.InvocationService"
 
+_METHOD_GET_AMP_LIMIT = f"{_SVC_AMP_LIMIT}/GetAmpLimit"
+_METHOD_SET_AMP_LIMIT = f"{_SVC_AMP_LIMIT}/SetAmpLimit"
 _METHOD_GET_TARGET_SOC = f"{_SVC_TARGET_SOC}/GetTargetSoc"
 _METHOD_SET_TARGET_SOC = f"{_SVC_TARGET_SOC}/SetTargetSoc"
 _METHOD_GET_CHARGE_TIMER = f"{_SVC_CHARGE_TIMER}/GetGlobalChargeTimerStream"
@@ -69,6 +72,22 @@ _METHOD_CLIMATIZATION_START = f"{_SVC_INVOCATION}/ClimatizationStart"
 _METHOD_CLIMATIZATION_STOP = f"{_SVC_INVOCATION}/ClimatizationStop"
 _METHOD_LOCK = f"{_SVC_INVOCATION}/Lock"
 _METHOD_UNLOCK = f"{_SVC_INVOCATION}/Unlock"
+
+# Chronos Status enum (pccs.chronos.messages.common.v1.Status)
+# Used by SetAmpLimitResponse — different from _RESPONSE_STATUS_NAMES!
+_CHRONOS_STATUS_NAMES = {
+    0: "UNKNOWN_ERROR",
+    1: "SENT",
+    2: "DELIVERED",
+    3: "SUCCESS",
+    4: "SYNCED",
+    5: "CAR_OFFLINE",
+    6: "CAR_ERROR",
+    7: "ERROR",
+    8: "REPLACED",
+}
+_CHRONOS_INTERMEDIATE_STATUSES = {1, 2}  # SENT, DELIVERED
+_CHRONOS_SUCCESS_STATUSES = {3, 4}  # SUCCESS, SYNCED
 
 _INVOCATION_EXPIRY_MS = 120_000  # command expiry: 120 seconds
 
@@ -106,6 +125,73 @@ def _build_chronos_request(vin: str) -> bytes:
 def _build_get_request(vin: str) -> bytes:
     """Build a Get*Request wrapping a ChronosRequest in field 1."""
     return _encode_field_bytes(1, _build_chronos_request(vin))
+
+
+def _build_set_amp_limit_request(vin: str, amp_limit: int) -> bytes:
+    """Build SetAmpLimit request bytes.
+
+    Args:
+        vin: Vehicle identification number.
+        amp_limit: Desired charging amperage limit (e.g. 16).
+    """
+    msg = _encode_field_bytes(1, _build_chronos_request(vin))
+    msg += _encode_field_varint(2, amp_limit)
+    return msg
+
+
+def _parse_amp_limit_response(data: bytes) -> dict:
+    """Parse GetAmpLimitResponse.
+
+    Response structure:
+        field 1: id (string)
+        field 2: vin (string)
+        field 3: ampLimit (AmpLimit sub-message)
+        field 4: pendingAmpLimit (AmpLimit sub-message)
+        field 5: updatedAt (varint)
+
+    AmpLimit sub-message:
+        field 1: ampLimit (int32)
+        field 2: updatedAt (int64)
+        field 3: source (string)
+        field 4: id (string)
+    """
+    if not data:
+        return {"amp_limit": None, "pending_amp_limit": None}
+
+    fields = _decode_message(data)
+
+    amp_limit_msg = _get_submessage(fields, 3)
+    pending_msg = _get_submessage(fields, 4)
+
+    amp_limit = _get_int(amp_limit_msg, 1, 0) if amp_limit_msg else 0
+    pending = _get_int(pending_msg, 1, 0) if pending_msg else 0
+
+    return {
+        "amp_limit": amp_limit or None,
+        "pending_amp_limit": pending or None,
+    }
+
+
+def _parse_set_amp_limit_response(data: bytes) -> dict:
+    """Parse SetAmpLimitResponse.
+
+    Response structure:
+        field 1: id (string)
+        field 2: vin (string)
+        field 3: status (Chronos Status enum: SUCCESS=3)
+        field 4: message (string)
+    """
+    if not data:
+        return {"id": "", "vin": "", "status": 0, "message": ""}
+
+    fields = _decode_message(data)
+
+    return {
+        "id": _get_string(fields, 1),
+        "vin": _get_string(fields, 2),
+        "status": _get_int(fields, 3, 0),
+        "message": _get_string(fields, 4),
+    }
 
 
 def _build_set_target_soc_request(vin: str, target_soc: int, setting_type: int = 3) -> bytes:
@@ -603,6 +689,65 @@ class PccsClient:
         if self._channel is not None:
             self._channel.close()
             self._channel = None
+
+    # -- Amp Limit -----------------------------------------------------------
+
+    def get_amp_limit(self, vin: str) -> dict:
+        """Get the current charging amperage limit for a vehicle.
+
+        GetAmpLimit is a server-streaming RPC; we take the first response.
+        """
+        channel = self._get_channel()
+        method = channel.unary_stream(
+            _METHOD_GET_AMP_LIMIT,
+            request_serializer=_identity_serialize,
+            response_deserializer=_identity_deserialize,
+        )
+        request = _build_get_request(vin)
+        try:
+            responses = method(request, metadata=self._metadata(vin), timeout=30)
+            for response in responses:
+                return _parse_amp_limit_response(response)
+            return _parse_amp_limit_response(b"")
+        except grpc.RpcError as err:
+            _LOGGER.warning("PCCS GetAmpLimit failed: %s", err)
+            raise
+
+    def set_amp_limit(self, vin: str, amp_limit: int) -> dict:
+        """Set the charging amperage limit for a vehicle.
+
+        SetAmpLimit is a server-streaming RPC that may emit intermediate
+        statuses (SENT, DELIVERED) before reaching a terminal status.
+        Requires the PCCS 2FA token (customer:attributes:write scope).
+        """
+        channel = self._get_channel()
+        method = channel.unary_stream(
+            _METHOD_SET_AMP_LIMIT,
+            request_serializer=_identity_serialize,
+            response_deserializer=_identity_deserialize,
+        )
+        request = _build_set_amp_limit_request(vin, amp_limit)
+        try:
+            responses = method(request, metadata=self._write_metadata(vin), timeout=30)
+            result = _parse_set_amp_limit_response(b"")
+            for response in responses:
+                result = _parse_set_amp_limit_response(response)
+                if result.get("status", 0) not in _CHRONOS_INTERMEDIATE_STATUSES:
+                    break
+        except grpc.RpcError as err:
+            _LOGGER.warning("PCCS SetAmpLimit failed: %s", err)
+            raise
+
+        status = result.get("status", 0)
+        if status not in _CHRONOS_SUCCESS_STATUSES:  # SUCCESS(3) or SYNCED(4)
+            status_name = _CHRONOS_STATUS_NAMES.get(status, f"STATUS_{status}")
+            server_msg = result.get("message", "")
+            msg = f"SetAmpLimit failed: {status_name}"
+            if server_msg:
+                msg += f" - {server_msg}"
+            raise PccsError(msg)
+
+        return result
 
     # -- Target SOC ----------------------------------------------------------
 

--- a/custom_components/polestar_soc/strings.json
+++ b/custom_components/polestar_soc/strings.json
@@ -82,6 +82,9 @@
       "charge_limit": {
         "name": "Charge limit"
       },
+      "amp_limit": {
+        "name": "Charging amp limit"
+      },
       "climate_timer_temperature": {
         "name": "Climate timer temperature"
       }

--- a/custom_components/polestar_soc/translations/en.json
+++ b/custom_components/polestar_soc/translations/en.json
@@ -82,6 +82,9 @@
       "charge_limit": {
         "name": "Charge limit"
       },
+      "amp_limit": {
+        "name": "Charging amp limit"
+      },
       "climate_timer_temperature": {
         "name": "Climate timer temperature"
       }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,6 +181,7 @@ def sample_coordinator_data(
         "battery": {vin: sample_battery},
         "odometer": {vin: sample_odometer},
         "target_soc": {},
+        "amp_limit": {},
         "charge_timer": {},
         "climate_timers": {},
         "climate_timer_settings": {},

--- a/tests/test_pccs.py
+++ b/tests/test_pccs.py
@@ -7,11 +7,13 @@ import pytest
 from custom_components.polestar_soc.pccs import (
     _METHOD_CLIMATIZATION_START,
     _METHOD_CLIMATIZATION_STOP,
+    _METHOD_GET_AMP_LIMIT,
     _METHOD_GET_CHARGE_TIMER,
     _METHOD_GET_CLIMATE_TIMER_SETTINGS,
     _METHOD_GET_CLIMATE_TIMERS,
     _METHOD_GET_TARGET_SOC,
     _METHOD_LOCK,
+    _METHOD_SET_AMP_LIMIT,
     _METHOD_SET_CHARGE_TIMER,
     _METHOD_SET_CLIMATE_TIMER_SETTINGS,
     _METHOD_SET_CLIMATE_TIMERS,
@@ -23,6 +25,7 @@ from custom_components.polestar_soc.pccs import (
     _build_invocation_request,
     _build_lock_request,
     _build_parking_climate_timer,
+    _build_set_amp_limit_request,
     _build_set_charge_timer_request,
     _build_set_climate_timer_settings_request,
     _build_set_climate_timers_request,
@@ -30,9 +33,11 @@ from custom_components.polestar_soc.pccs import (
     _build_time_of_day,
     _build_unlock_request,
     _lock_error_context,
+    _parse_amp_limit_response,
     _parse_charge_timer_response,
     _parse_climate_timer_settings_response,
     _parse_climate_timers_response,
+    _parse_set_amp_limit_response,
     _parse_set_charge_timer_response,
     _parse_set_climate_timers_response,
     _parse_target_soc_response,
@@ -73,6 +78,12 @@ class TestServicePaths:
     def test_charge_timer_set_path(self):
         expected = "/pccs.chronos.services.v2.GlobalChargeTimerService/SetGlobalChargeTimer"
         assert expected == _METHOD_SET_CHARGE_TIMER
+
+    def test_amp_limit_get_path(self):
+        assert _METHOD_GET_AMP_LIMIT == "/pccs.chronos.services.v1.AmpLimitService/GetAmpLimit"
+
+    def test_amp_limit_set_path(self):
+        assert _METHOD_SET_AMP_LIMIT == "/pccs.chronos.services.v1.AmpLimitService/SetAmpLimit"
 
     def test_climatization_start_path(self):
         expected = "/pccs.invocation.v1.InvocationService/ClimatizationStart"
@@ -1170,3 +1181,114 @@ class TestBuildSetClimateTimerSettingsRequest:
         fields = _decode_message(data)
         settings = _get_submessage(fields, 2)
         assert _get_float(settings, 3) == pytest.approx(18.5)
+
+
+# ---------------------------------------------------------------------------
+# Amp limit parsers
+# ---------------------------------------------------------------------------
+
+
+class TestParseAmpLimitResponse:
+    def test_empty_data(self):
+        result = _parse_amp_limit_response(b"")
+        assert result["amp_limit"] is None
+        assert result["pending_amp_limit"] is None
+
+    def test_basic_response(self):
+        # AmpLimit sub-message in field 3: field 1 = ampLimit (16)
+        inner = _encode_field_varint(1, 16)
+        data = _encode_field_bytes(3, inner)
+        result = _parse_amp_limit_response(data)
+        assert result["amp_limit"] == 16
+        assert result["pending_amp_limit"] is None
+
+    def test_with_pending(self):
+        inner = _encode_field_varint(1, 16)
+        pending = _encode_field_varint(1, 10)
+        data = _encode_field_bytes(3, inner) + _encode_field_bytes(4, pending)
+        result = _parse_amp_limit_response(data)
+        assert result["amp_limit"] == 16
+        assert result["pending_amp_limit"] == 10
+
+    def test_zero_converts_to_none(self):
+        """Proto3 default 0 should be treated as 'not set'."""
+        inner = _encode_field_varint(1, 0)
+        data = _encode_field_bytes(3, inner)
+        result = _parse_amp_limit_response(data)
+        assert result["amp_limit"] is None
+
+    def test_full_response_with_id_and_vin(self):
+        """Response with all envelope fields present."""
+        inner = _encode_field_varint(1, 32)
+        data = (
+            _encode_field_bytes(1, b"req-uuid")
+            + _encode_field_bytes(2, b"TESTVIN123")
+            + _encode_field_bytes(3, inner)
+            + _encode_field_varint(5, 1773247754487)
+        )
+        result = _parse_amp_limit_response(data)
+        assert result["amp_limit"] == 32
+        assert result["pending_amp_limit"] is None
+
+
+class TestParseSetAmpLimitResponse:
+    def test_empty_data(self):
+        result = _parse_set_amp_limit_response(b"")
+        assert result["id"] == ""
+        assert result["vin"] == ""
+        assert result["status"] == 0
+        assert result["message"] == ""
+
+    def test_success(self):
+        data = (
+            _encode_field_bytes(1, b"req-uuid")
+            + _encode_field_bytes(2, b"TESTVIN123")
+            + _encode_field_varint(3, 3)  # SUCCESS in Chronos Status enum
+        )
+        result = _parse_set_amp_limit_response(data)
+        assert result["id"] == "req-uuid"
+        assert result["vin"] == "TESTVIN123"
+        assert result["status"] == 3
+        assert result["message"] == ""
+
+    def test_error_with_message(self):
+        data = (
+            _encode_field_bytes(1, b"req-uuid")
+            + _encode_field_bytes(2, b"TESTVIN123")
+            + _encode_field_varint(3, 7)  # ERROR
+            + _encode_field_bytes(4, b"Vehicle rejected command")
+        )
+        result = _parse_set_amp_limit_response(data)
+        assert result["status"] == 7
+        assert result["message"] == "Vehicle rejected command"
+
+    def test_intermediate_status_sent(self):
+        data = (
+            _encode_field_bytes(1, b"req-uuid")
+            + _encode_field_bytes(2, b"TESTVIN123")
+            + _encode_field_varint(3, 1)  # SENT
+        )
+        result = _parse_set_amp_limit_response(data)
+        assert result["status"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Amp limit request builder
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSetAmpLimitRequest:
+    def test_structure(self):
+        data = _build_set_amp_limit_request("TESTVIN123", 16)
+        fields = _decode_message(data)
+        # Field 1: ChronosRequest
+        chronos = _decode_message(fields[1][0])
+        assert chronos[2] == [b"TESTVIN123"]
+        # Field 2: ampLimit (varint)
+        assert fields[2] == [16]
+
+    def test_different_values(self):
+        for amp_val in (6, 10, 16, 20, 32):
+            data = _build_set_amp_limit_request("VIN", amp_val)
+            fields = _decode_message(data)
+            assert fields[2] == [amp_val]


### PR DESCRIPTION
## Summary
- Add a number entity (slider 6-32A, step 1) to control the global charging amperage limit via the PCCS AmpLimitService gRPC API
- Read uses web token, write uses PCCS 2FA token (same pattern as charge limit)
- SetAmpLimit streams intermediate statuses (SENT → DELIVERED → SYNCED); the implementation iterates until terminal status
- Prefers pending amp limit over baseline in the UI when a change is in flight

## Changes
- **pccs.py**: `get_amp_limit()` / `set_amp_limit()` client methods, request builder, response parsers, Chronos Status enum map
- **coordinator.py**: `amp_limit` data fetching per VIN
- **number.py**: `PolestarAmpLimitNumber` entity (6-32A slider)
- **strings.json / en.json**: "Charging amp limit" translation
- **tests**: Parser, builder, and service path tests

## Test plan
- [x] Unit tests pass (308 total)
- [x] Live API: GetAmpLimit returns correct value
- [x] Live API: SetAmpLimit writes successfully (SENT → DELIVERED → SYNCED)
- [x] Live API: Read-after-write confirms value persisted