### PR TITLE
Add vehicle health entities

### DIFF
--- a/custom_components/polestar_soc/binary_sensor.py
+++ b/custom_components/polestar_soc/binary_sensor.py
@@ -16,7 +16,17 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ALARM_STATUS_MAP, DOMAIN, OPEN_STATUS_MAP, UNAVAILABLE_REASON_MAP
+from .const import (
+    ALARM_STATUS_MAP,
+    DOMAIN,
+    EXTERIOR_LIGHT_WARNING_MAP,
+    FLUID_WARNING_MAP,
+    LOW_VOLTAGE_BATTERY_WARNING_MAP,
+    OIL_LEVEL_WARNING_MAP,
+    OPEN_STATUS_MAP,
+    TYRE_PRESSURE_WARNING_MAP,
+    UNAVAILABLE_REASON_MAP,
+)
 from .coordinator import PolestarCoordinator
 
 
@@ -80,6 +90,93 @@ def _availability_extra_attrs(data: dict, vin: str) -> dict | None:
     reason_val = availability.get("unavailable_reason")
     reason = UNAVAILABLE_REASON_MAP.get(reason_val) if reason_val else None
     return {"unavailable_reason": reason}
+
+
+# ---------------------------------------------------------------------------
+# Health warning helpers
+# ---------------------------------------------------------------------------
+
+
+def _health_warning_is_on(
+    warning_key: str, *, threshold: int = 2
+) -> Callable[[dict, str], bool | None]:
+    """Create an is_on_fn for a health warning field.
+
+    Returns True when warning value >= threshold (default 2, meaning any
+    non-OK warning state). Returns None when data is missing or UNSPECIFIED(0).
+    """
+
+    def _fn(data: dict, vin: str) -> bool | None:
+        health = data.get("health", {}).get(vin)
+        if health is None:
+            return None
+        val = health.get(warning_key)
+        if val is None:
+            return None
+        return val >= threshold
+
+    return _fn
+
+
+def _health_warning_exact_is_on(
+    warning_key: str, on_value: int
+) -> Callable[[dict, str], bool | None]:
+    """Create an is_on_fn that triggers on a specific warning value."""
+
+    def _fn(data: dict, vin: str) -> bool | None:
+        health = data.get("health", {}).get(vin)
+        if health is None:
+            return None
+        val = health.get(warning_key)
+        if val is None:
+            return None
+        return val == on_value
+
+    return _fn
+
+
+def _health_warning_attrs(
+    warning_key: str, label_map: dict[int, str | None]
+) -> Callable[[dict, str], dict | None]:
+    """Create an extra_attrs_fn for a health warning binary sensor."""
+
+    def _fn(data: dict, vin: str) -> dict | None:
+        health = data.get("health", {}).get(vin)
+        if health is None:
+            return None
+        val = health.get(warning_key)
+        if val is None:
+            return None
+        label = label_map.get(val, f"Unknown ({val})")
+        if label is None:
+            return None
+        return {"raw_state": label}
+
+    return _fn
+
+
+def _tyre_warning_attrs(
+    warning_key: str, pressure_key: str
+) -> Callable[[dict, str], dict | None]:
+    """Create an extra_attrs_fn for tyre pressure warning (includes kPa value)."""
+
+    def _fn(data: dict, vin: str) -> dict | None:
+        health = data.get("health", {}).get(vin)
+        if health is None:
+            return None
+        val = health.get(warning_key)
+        if val is None:
+            return None
+        label = TYRE_PRESSURE_WARNING_MAP.get(val, f"Unknown ({val})")
+        if label is None:
+            return None
+        attrs: dict = {"raw_state": label}
+        pressure = health.get(pressure_key)
+        if pressure is not None:
+            attrs["pressure_kpa"] = pressure
+        return attrs
+
+    return _fn
 
 
 # ---------------------------------------------------------------------------
@@ -181,6 +278,298 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PolestarBinarySensorDescription, ...] = (
         device_class=BinarySensorDeviceClass.SAFETY,
         entity_registry_enabled_default=False,
         is_on_fn=_alarm_is_on,
+    ),
+    # -- Health: Tyre pressure warnings (enabled by default) --
+    PolestarBinarySensorDescription(
+        key="front_left_tyre_pressure_warning",
+        translation_key="front_left_tyre_pressure_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        is_on_fn=_health_warning_is_on("front_left_tyre_pressure_warning"),
+        extra_attrs_fn=_tyre_warning_attrs(
+            "front_left_tyre_pressure_warning", "front_left_tyre_pressure_kpa"
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="front_right_tyre_pressure_warning",
+        translation_key="front_right_tyre_pressure_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        is_on_fn=_health_warning_is_on("front_right_tyre_pressure_warning"),
+        extra_attrs_fn=_tyre_warning_attrs(
+            "front_right_tyre_pressure_warning", "front_right_tyre_pressure_kpa"
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="rear_left_tyre_pressure_warning",
+        translation_key="rear_left_tyre_pressure_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        is_on_fn=_health_warning_is_on("rear_left_tyre_pressure_warning"),
+        extra_attrs_fn=_tyre_warning_attrs(
+            "rear_left_tyre_pressure_warning", "rear_left_tyre_pressure_kpa"
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="rear_right_tyre_pressure_warning",
+        translation_key="rear_right_tyre_pressure_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        is_on_fn=_health_warning_is_on("rear_right_tyre_pressure_warning"),
+        extra_attrs_fn=_tyre_warning_attrs(
+            "rear_right_tyre_pressure_warning", "rear_right_tyre_pressure_kpa"
+        ),
+    ),
+    # -- Health: Fluid & battery warnings (enabled by default) --
+    PolestarBinarySensorDescription(
+        key="washer_fluid_level_warning",
+        translation_key="washer_fluid_level_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        is_on_fn=_health_warning_exact_is_on("washer_fluid_level_warning", 2),
+        extra_attrs_fn=_health_warning_attrs("washer_fluid_level_warning", FLUID_WARNING_MAP),
+    ),
+    PolestarBinarySensorDescription(
+        key="low_voltage_battery_warning",
+        translation_key="low_voltage_battery_warning",
+        device_class=BinarySensorDeviceClass.BATTERY,
+        is_on_fn=_health_warning_exact_is_on("low_voltage_battery_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "low_voltage_battery_warning", LOW_VOLTAGE_BATTERY_WARNING_MAP
+        ),
+    ),
+    # -- Health: Disabled by default --
+    PolestarBinarySensorDescription(
+        key="brake_fluid_level_warning",
+        translation_key="brake_fluid_level_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_is_on("brake_fluid_level_warning"),
+        extra_attrs_fn=_health_warning_attrs("brake_fluid_level_warning", FLUID_WARNING_MAP),
+    ),
+    PolestarBinarySensorDescription(
+        key="engine_coolant_level_warning",
+        translation_key="engine_coolant_level_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_is_on("engine_coolant_level_warning"),
+        extra_attrs_fn=_health_warning_attrs(
+            "engine_coolant_level_warning", FLUID_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="oil_level_warning",
+        translation_key="oil_level_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_is_on("oil_level_warning"),
+        extra_attrs_fn=_health_warning_attrs("oil_level_warning", OIL_LEVEL_WARNING_MAP),
+    ),
+    # -- Health: Light warnings (disabled by default) --
+    PolestarBinarySensorDescription(
+        key="brake_light_left_warning",
+        translation_key="brake_light_left_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("brake_light_left_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "brake_light_left_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="brake_light_center_warning",
+        translation_key="brake_light_center_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("brake_light_center_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "brake_light_center_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="brake_light_right_warning",
+        translation_key="brake_light_right_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("brake_light_right_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "brake_light_right_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="fog_light_front_warning",
+        translation_key="fog_light_front_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("fog_light_front_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "fog_light_front_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="fog_light_rear_warning",
+        translation_key="fog_light_rear_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("fog_light_rear_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "fog_light_rear_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="position_light_front_left_warning",
+        translation_key="position_light_front_left_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("position_light_front_left_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "position_light_front_left_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="position_light_front_right_warning",
+        translation_key="position_light_front_right_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("position_light_front_right_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "position_light_front_right_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="position_light_rear_left_warning",
+        translation_key="position_light_rear_left_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("position_light_rear_left_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "position_light_rear_left_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="position_light_rear_right_warning",
+        translation_key="position_light_rear_right_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("position_light_rear_right_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "position_light_rear_right_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="high_beam_left_warning",
+        translation_key="high_beam_left_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("high_beam_left_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "high_beam_left_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="high_beam_right_warning",
+        translation_key="high_beam_right_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("high_beam_right_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "high_beam_right_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="low_beam_left_warning",
+        translation_key="low_beam_left_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("low_beam_left_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "low_beam_left_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="low_beam_right_warning",
+        translation_key="low_beam_right_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("low_beam_right_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "low_beam_right_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="daytime_running_light_left_warning",
+        translation_key="daytime_running_light_left_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("daytime_running_light_left_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "daytime_running_light_left_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="daytime_running_light_right_warning",
+        translation_key="daytime_running_light_right_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("daytime_running_light_right_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "daytime_running_light_right_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="turn_indication_front_left_warning",
+        translation_key="turn_indication_front_left_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("turn_indication_front_left_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "turn_indication_front_left_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="turn_indication_front_right_warning",
+        translation_key="turn_indication_front_right_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("turn_indication_front_right_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "turn_indication_front_right_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="turn_indication_rear_left_warning",
+        translation_key="turn_indication_rear_left_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("turn_indication_rear_left_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "turn_indication_rear_left_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="turn_indication_rear_right_warning",
+        translation_key="turn_indication_rear_right_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("turn_indication_rear_right_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "turn_indication_rear_right_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="registration_plate_light_warning",
+        translation_key="registration_plate_light_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("registration_plate_light_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "registration_plate_light_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
+    ),
+    PolestarBinarySensorDescription(
+        key="side_mark_lights_warning",
+        translation_key="side_mark_lights_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+        is_on_fn=_health_warning_exact_is_on("side_mark_lights_warning", 2),
+        extra_attrs_fn=_health_warning_attrs(
+            "side_mark_lights_warning", EXTERIOR_LIGHT_WARNING_MAP
+        ),
     ),
 )
 

--- a/custom_components/polestar_soc/binary_sensor.py
+++ b/custom_components/polestar_soc/binary_sensor.py
@@ -155,9 +155,7 @@ def _health_warning_attrs(
     return _fn
 
 
-def _tyre_warning_attrs(
-    warning_key: str, pressure_key: str
-) -> Callable[[dict, str], dict | None]:
+def _tyre_warning_attrs(warning_key: str, pressure_key: str) -> Callable[[dict, str], dict | None]:
     """Create an extra_attrs_fn for tyre pressure warning (includes kPa value)."""
 
     def _fn(data: dict, vin: str) -> dict | None:
@@ -348,9 +346,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PolestarBinarySensorDescription, ...] = (
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_registry_enabled_default=False,
         is_on_fn=_health_warning_is_on("engine_coolant_level_warning"),
-        extra_attrs_fn=_health_warning_attrs(
-            "engine_coolant_level_warning", FLUID_WARNING_MAP
-        ),
+        extra_attrs_fn=_health_warning_attrs("engine_coolant_level_warning", FLUID_WARNING_MAP),
     ),
     PolestarBinarySensorDescription(
         key="oil_level_warning",
@@ -397,9 +393,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PolestarBinarySensorDescription, ...] = (
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_registry_enabled_default=False,
         is_on_fn=_health_warning_exact_is_on("fog_light_front_warning", 2),
-        extra_attrs_fn=_health_warning_attrs(
-            "fog_light_front_warning", EXTERIOR_LIGHT_WARNING_MAP
-        ),
+        extra_attrs_fn=_health_warning_attrs("fog_light_front_warning", EXTERIOR_LIGHT_WARNING_MAP),
     ),
     PolestarBinarySensorDescription(
         key="fog_light_rear_warning",
@@ -407,9 +401,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PolestarBinarySensorDescription, ...] = (
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_registry_enabled_default=False,
         is_on_fn=_health_warning_exact_is_on("fog_light_rear_warning", 2),
-        extra_attrs_fn=_health_warning_attrs(
-            "fog_light_rear_warning", EXTERIOR_LIGHT_WARNING_MAP
-        ),
+        extra_attrs_fn=_health_warning_attrs("fog_light_rear_warning", EXTERIOR_LIGHT_WARNING_MAP),
     ),
     PolestarBinarySensorDescription(
         key="position_light_front_left_warning",
@@ -457,9 +449,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PolestarBinarySensorDescription, ...] = (
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_registry_enabled_default=False,
         is_on_fn=_health_warning_exact_is_on("high_beam_left_warning", 2),
-        extra_attrs_fn=_health_warning_attrs(
-            "high_beam_left_warning", EXTERIOR_LIGHT_WARNING_MAP
-        ),
+        extra_attrs_fn=_health_warning_attrs("high_beam_left_warning", EXTERIOR_LIGHT_WARNING_MAP),
     ),
     PolestarBinarySensorDescription(
         key="high_beam_right_warning",
@@ -467,9 +457,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PolestarBinarySensorDescription, ...] = (
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_registry_enabled_default=False,
         is_on_fn=_health_warning_exact_is_on("high_beam_right_warning", 2),
-        extra_attrs_fn=_health_warning_attrs(
-            "high_beam_right_warning", EXTERIOR_LIGHT_WARNING_MAP
-        ),
+        extra_attrs_fn=_health_warning_attrs("high_beam_right_warning", EXTERIOR_LIGHT_WARNING_MAP),
     ),
     PolestarBinarySensorDescription(
         key="low_beam_left_warning",
@@ -477,9 +465,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PolestarBinarySensorDescription, ...] = (
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_registry_enabled_default=False,
         is_on_fn=_health_warning_exact_is_on("low_beam_left_warning", 2),
-        extra_attrs_fn=_health_warning_attrs(
-            "low_beam_left_warning", EXTERIOR_LIGHT_WARNING_MAP
-        ),
+        extra_attrs_fn=_health_warning_attrs("low_beam_left_warning", EXTERIOR_LIGHT_WARNING_MAP),
     ),
     PolestarBinarySensorDescription(
         key="low_beam_right_warning",
@@ -487,9 +473,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PolestarBinarySensorDescription, ...] = (
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_registry_enabled_default=False,
         is_on_fn=_health_warning_exact_is_on("low_beam_right_warning", 2),
-        extra_attrs_fn=_health_warning_attrs(
-            "low_beam_right_warning", EXTERIOR_LIGHT_WARNING_MAP
-        ),
+        extra_attrs_fn=_health_warning_attrs("low_beam_right_warning", EXTERIOR_LIGHT_WARNING_MAP),
     ),
     PolestarBinarySensorDescription(
         key="daytime_running_light_left_warning",

--- a/custom_components/polestar_soc/cep.py
+++ b/custom_components/polestar_soc/cep.py
@@ -357,6 +357,9 @@ def _parse_health_response(data: bytes) -> dict:
     if state is None:
         return empty
 
+    def _int_or_none(field_num: int) -> int | None:
+        return _get_int(state, field_num) if field_num in state else None
+
     def _pressure(field_num: int) -> float | None:
         val = _get_float(state, field_num)
         return round(val, 1) if val is not None else None
@@ -366,8 +369,8 @@ def _parse_health_response(data: bytes) -> dict:
         return val if val else None  # 0 (UNSPECIFIED) → None
 
     result: dict = {
-        "days_to_service": _get_int(state, 3) or None,
-        "distance_to_service_km": _get_int(state, 4) or None,
+        "days_to_service": _int_or_none(3),
+        "distance_to_service_km": _int_or_none(4),
         "service_warning": _warning(5),
         "brake_fluid_level_warning": _warning(6),
         "engine_coolant_level_warning": _warning(7),

--- a/custom_components/polestar_soc/cep.py
+++ b/custom_components/polestar_soc/cep.py
@@ -562,9 +562,7 @@ class CepClient:
             response_deserializer=_identity_deserialize,
         )
         try:
-            responses = method(
-                _build_vin_request(vin), metadata=self._metadata(vin), timeout=30
-            )
+            responses = method(_build_vin_request(vin), metadata=self._metadata(vin), timeout=30)
             for response in responses:
                 return _parse_health_response(response)
         except grpc.RpcError as err:

--- a/custom_components/polestar_soc/cep.py
+++ b/custom_components/polestar_soc/cep.py
@@ -26,6 +26,7 @@ from .proto import (
     _encode_field_bytes,
     _encode_field_varint,
     _get_double,
+    _get_float,
     _get_int,
     _get_submessage,
     _identity_deserialize,
@@ -45,6 +46,7 @@ _METHOD_GET_EXTERIOR = "/services.vehiclestates.exterior.ExteriorService/GetLate
 _METHOD_GET_AVAILABILITY = (
     "/services.vehiclestates.availability.AvailabilityService/GetLatestAvailability"
 )
+_METHOD_GET_HEALTH = "/services.vehiclestates.health.HealthService/GetHealth"
 _METHOD_GET_LOCATION = "/dtlinternet.DtlInternetService/GetLastKnownLocation"
 _SVC_INVOCATION = "/invocation.InvocationService"
 _METHOD_WINDOW_CONTROL = f"{_SVC_INVOCATION}/WindowControl"
@@ -272,6 +274,123 @@ def _parse_availability_response(data: bytes) -> dict:
     }
 
 
+# Health light warning field numbers → dict keys
+_LIGHT_WARNING_FIELDS: tuple[tuple[int, str], ...] = (
+    (14, "brake_light_left_warning"),
+    (15, "brake_light_center_warning"),
+    (16, "brake_light_right_warning"),
+    (17, "fog_light_front_warning"),
+    (18, "fog_light_rear_warning"),
+    (19, "position_light_front_left_warning"),
+    (20, "position_light_front_right_warning"),
+    (21, "position_light_rear_left_warning"),
+    (22, "position_light_rear_right_warning"),
+    (23, "high_beam_left_warning"),
+    (24, "high_beam_right_warning"),
+    (25, "low_beam_left_warning"),
+    (26, "low_beam_right_warning"),
+    (27, "daytime_running_light_left_warning"),
+    (28, "daytime_running_light_right_warning"),
+    (30, "turn_indication_front_left_warning"),
+    (31, "turn_indication_front_right_warning"),
+    (32, "turn_indication_rear_left_warning"),
+    (33, "turn_indication_rear_right_warning"),
+    (34, "registration_plate_light_warning"),
+    (35, "side_mark_lights_warning"),
+)
+
+
+def _parse_health_response(data: bytes) -> dict:
+    """Parse GetHealth response.
+
+    Two-level decode: outer envelope has field 3 = Health sub-message.
+
+    Health state field mapping:
+        field 3:  days_to_service (int32)
+        field 4:  distance_to_service_km (int32)
+        field 5:  service_warning (ServiceWarning enum)
+        field 6:  brake_fluid_level_warning (enum)
+        field 7:  engine_coolant_level_warning (enum)
+        field 8:  oil_level_warning (enum)
+        field 9:  front_left_tyre_pressure_warning (enum)
+        field 10: front_right_tyre_pressure_warning (enum)
+        field 11: rear_left_tyre_pressure_warning (enum)
+        field 12: rear_right_tyre_pressure_warning (enum)
+        field 13: washer_fluid_level_warning (enum)
+        field 14-35: light warnings (ExteriorLightWarning enum)
+        field 38: low_voltage_battery_warning (enum)
+        field 39: front_left_tyre_pressure_kpa (float/fixed32)
+        field 40: front_right_tyre_pressure_kpa (float/fixed32)
+        field 41: rear_left_tyre_pressure_kpa (float/fixed32)
+        field 42: rear_right_tyre_pressure_kpa (float/fixed32)
+        field 43: front_tyres_reference_pressure_kpa (float/fixed32)
+        field 44: rear_tyres_reference_pressure_kpa (float/fixed32)
+    """
+    empty: dict = {
+        "days_to_service": None,
+        "distance_to_service_km": None,
+        "service_warning": None,
+        "brake_fluid_level_warning": None,
+        "engine_coolant_level_warning": None,
+        "oil_level_warning": None,
+        "front_left_tyre_pressure_warning": None,
+        "front_right_tyre_pressure_warning": None,
+        "rear_left_tyre_pressure_warning": None,
+        "rear_right_tyre_pressure_warning": None,
+        "washer_fluid_level_warning": None,
+        "low_voltage_battery_warning": None,
+        "front_left_tyre_pressure_kpa": None,
+        "front_right_tyre_pressure_kpa": None,
+        "rear_left_tyre_pressure_kpa": None,
+        "rear_right_tyre_pressure_kpa": None,
+        "front_tyres_reference_pressure_kpa": None,
+        "rear_tyres_reference_pressure_kpa": None,
+    }
+    for _, key in _LIGHT_WARNING_FIELDS:
+        empty[key] = None
+
+    if not data:
+        return empty
+
+    outer = _decode_message(data)
+    state = _get_submessage(outer, 3)
+    if state is None:
+        return empty
+
+    def _pressure(field_num: int) -> float | None:
+        val = _get_float(state, field_num)
+        return round(val, 1) if val is not None else None
+
+    def _warning(field_num: int) -> int | None:
+        val = _get_int(state, field_num)
+        return val if val else None  # 0 (UNSPECIFIED) → None
+
+    result: dict = {
+        "days_to_service": _get_int(state, 3) or None,
+        "distance_to_service_km": _get_int(state, 4) or None,
+        "service_warning": _warning(5),
+        "brake_fluid_level_warning": _warning(6),
+        "engine_coolant_level_warning": _warning(7),
+        "oil_level_warning": _warning(8),
+        "front_left_tyre_pressure_warning": _warning(9),
+        "front_right_tyre_pressure_warning": _warning(10),
+        "rear_left_tyre_pressure_warning": _warning(11),
+        "rear_right_tyre_pressure_warning": _warning(12),
+        "washer_fluid_level_warning": _warning(13),
+        "low_voltage_battery_warning": _warning(38),
+        "front_left_tyre_pressure_kpa": _pressure(39),
+        "front_right_tyre_pressure_kpa": _pressure(40),
+        "rear_left_tyre_pressure_kpa": _pressure(41),
+        "rear_right_tyre_pressure_kpa": _pressure(42),
+        "front_tyres_reference_pressure_kpa": _pressure(43),
+        "rear_tyres_reference_pressure_kpa": _pressure(44),
+    }
+    for field_num, key in _LIGHT_WARNING_FIELDS:
+        result[key] = _warning(field_num)
+
+    return result
+
+
 def _parse_location_response(data: bytes) -> dict:
     """Parse GetLastKnownLocation response.
 
@@ -426,6 +545,30 @@ class CepClient:
         except grpc.RpcError as err:
             _LOGGER.warning("CEP GetLatestAvailability failed: %s", err)
             raise
+
+    def get_health(self, vin: str) -> dict:
+        """Get vehicle health state (tyre pressure, fluid levels, service info).
+
+        GetHealth is SERVER_STREAMING (no GetLatest* unary variant).
+        Takes the first response from the stream and returns parsed data.
+        """
+        channel = self._get_channel()
+        method = channel.unary_stream(
+            _METHOD_GET_HEALTH,
+            request_serializer=_identity_serialize,
+            response_deserializer=_identity_deserialize,
+        )
+        try:
+            responses = method(
+                _build_vin_request(vin), metadata=self._metadata(vin), timeout=30
+            )
+            for response in responses:
+                return _parse_health_response(response)
+        except grpc.RpcError as err:
+            _LOGGER.warning("CEP GetHealth failed: %s", err)
+            raise
+        # Stream yielded no responses
+        return _parse_health_response(b"")
 
     def get_location(self, vin: str) -> dict:
         """Get last known vehicle location."""

--- a/custom_components/polestar_soc/const.py
+++ b/custom_components/polestar_soc/const.py
@@ -144,6 +144,57 @@ USAGE_MODE_MAP: dict[int, str] = {
     7: "Engine off",
 }
 
+# Health service enums (HealthService)
+TYRE_PRESSURE_WARNING_MAP: dict[int, str | None] = {
+    0: None,
+    1: "No warning",
+    2: "Very low",
+    3: "Low",
+    4: "High",
+}
+
+SERVICE_WARNING_MAP: dict[int, str] = {
+    0: "Unknown",
+    1: "No warning",
+    2: "Unknown warning",
+    3: "Almost time for service (regular)",
+    4: "Almost time for service (engine hours)",
+    5: "Almost time for service (distance)",
+    6: "Time for service (regular)",
+    7: "Time for service (engine hours)",
+    8: "Time for service (distance)",
+    9: "Overdue for service (regular)",
+    10: "Overdue for service (engine hours)",
+    11: "Overdue for service (distance)",
+}
+
+OIL_LEVEL_WARNING_MAP: dict[int, str | None] = {
+    0: None,
+    1: "No warning",
+    2: "Service required",
+    3: "Too low",
+    4: "Too high",
+}
+
+FLUID_WARNING_MAP: dict[int, str | None] = {
+    0: None,
+    1: "No warning",
+    2: "Too low",
+    3: "Critically low",  # BrakeFluidLevelWarning only
+}
+
+LOW_VOLTAGE_BATTERY_WARNING_MAP: dict[int, str | None] = {
+    0: None,
+    1: "No warning",
+    2: "Too low",
+}
+
+EXTERIOR_LIGHT_WARNING_MAP: dict[int, str | None] = {
+    0: None,
+    1: "No warning",
+    2: "Failure",
+}
+
 # Weekday enum (ParkingClimateTimer)
 WEEKDAY_MAP: dict[int, str] = {
     1: "Monday",

--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -528,6 +528,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
                     "location": {},
                     "exterior": {},
                     "availability": {},
+                    "health": {},
                 }
 
             vins = [v["vin"] for v in vehicles]
@@ -579,6 +580,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
             location_by_vin: dict = {}
             exterior_by_vin: dict = {}
             availability_by_vin: dict = {}
+            health_by_vin: dict = {}
             for vin in vins:
                 try:
                     climate_by_vin[vin] = self.cep.get_parking_climatization(vin)
@@ -600,6 +602,10 @@ class PolestarCoordinator(DataUpdateCoordinator):
                     availability_by_vin[vin] = self.cep.get_availability(vin)
                 except Exception:
                     _LOGGER.debug("Failed to fetch CEP availability for %s", vin)
+                try:
+                    health_by_vin[vin] = self.cep.get_health(vin)
+                except Exception:
+                    _LOGGER.debug("Failed to fetch CEP health for %s", vin)
 
             return {
                 "vehicles": vehicles,
@@ -615,6 +621,7 @@ class PolestarCoordinator(DataUpdateCoordinator):
                 "location": location_by_vin,
                 "exterior": exterior_by_vin,
                 "availability": availability_by_vin,
+                "health": health_by_vin,
             }
 
         return await self.hass.async_add_executor_job(_do_fetch)

--- a/custom_components/polestar_soc/sensor.py
+++ b/custom_components/polestar_soc/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfTime
+from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfPressure, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -22,6 +22,7 @@ from .const import (
     CLIMATE_RUNNING_STATUS_MAP,
     DOMAIN,
     HEATING_INTENSITY_MAP,
+    SERVICE_WARNING_MAP,
     UNAVAILABLE_REASON_MAP,
     USAGE_MODE_MAP,
 )
@@ -117,11 +118,46 @@ def _estimated_range(data: dict, vin: str) -> int | None:
     return cep_battery.get("estimated_range_km")
 
 
+def _health_pressure(key: str) -> Callable[[dict, str], float | None]:
+    """Create a value_fn for a tyre pressure sensor (kPa)."""
+
+    def _value_fn(data: dict, vin: str) -> float | None:
+        health = data.get("health", {}).get(vin)
+        if health is None:
+            return None
+        return health.get(key)
+
+    return _value_fn
+
+
+def _health_int(key: str) -> Callable[[dict, str], int | None]:
+    """Create a value_fn for a health integer sensor (days/distance to service)."""
+
+    def _value_fn(data: dict, vin: str) -> int | None:
+        health = data.get("health", {}).get(vin)
+        if health is None:
+            return None
+        return health.get(key)
+
+    return _value_fn
+
+
+def _service_warning(data: dict, vin: str) -> str | None:
+    health = data.get("health", {}).get(vin)
+    if health is None:
+        return None
+    val = health.get("service_warning")
+    if val is None:
+        return None
+    return SERVICE_WARNING_MAP.get(val)
+
+
 # Options lists for ENUM sensors
 _CLIMATE_STATUS_OPTIONS = list(CLIMATE_RUNNING_STATUS_MAP.values())
 _HEATING_INTENSITY_OPTIONS = list(HEATING_INTENSITY_MAP.values())
 _USAGE_MODE_OPTIONS = list(USAGE_MODE_MAP.values())
 _UNAVAILABLE_REASON_OPTIONS = list(UNAVAILABLE_REASON_MAP.values())
+_SERVICE_WARNING_OPTIONS = list(SERVICE_WARNING_MAP.values())
 
 SENSOR_DESCRIPTIONS: tuple[PolestarSensorDescription, ...] = (
     PolestarSensorDescription(
@@ -217,6 +253,68 @@ SENSOR_DESCRIPTIONS: tuple[PolestarSensorDescription, ...] = (
         options=_UNAVAILABLE_REASON_OPTIONS,
         entity_registry_enabled_default=False,
         value_fn=_unavailable_reason,
+    ),
+    # -- Health: Tyre pressure sensors --
+    PolestarSensorDescription(
+        key="front_left_tyre_pressure",
+        translation_key="front_left_tyre_pressure",
+        native_unit_of_measurement=UnitOfPressure.KPA,
+        device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        value_fn=_health_pressure("front_left_tyre_pressure_kpa"),
+    ),
+    PolestarSensorDescription(
+        key="front_right_tyre_pressure",
+        translation_key="front_right_tyre_pressure",
+        native_unit_of_measurement=UnitOfPressure.KPA,
+        device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        value_fn=_health_pressure("front_right_tyre_pressure_kpa"),
+    ),
+    PolestarSensorDescription(
+        key="rear_left_tyre_pressure",
+        translation_key="rear_left_tyre_pressure",
+        native_unit_of_measurement=UnitOfPressure.KPA,
+        device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        value_fn=_health_pressure("rear_left_tyre_pressure_kpa"),
+    ),
+    PolestarSensorDescription(
+        key="rear_right_tyre_pressure",
+        translation_key="rear_right_tyre_pressure",
+        native_unit_of_measurement=UnitOfPressure.KPA,
+        device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        value_fn=_health_pressure("rear_right_tyre_pressure_kpa"),
+    ),
+    # -- Health: Service info --
+    PolestarSensorDescription(
+        key="days_to_service",
+        translation_key="days_to_service",
+        native_unit_of_measurement=UnitOfTime.DAYS,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        value_fn=_health_int("days_to_service"),
+    ),
+    PolestarSensorDescription(
+        key="distance_to_service",
+        translation_key="distance_to_service",
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        value_fn=_health_int("distance_to_service_km"),
+    ),
+    PolestarSensorDescription(
+        key="service_warning",
+        translation_key="service_warning",
+        device_class=SensorDeviceClass.ENUM,
+        options=_SERVICE_WARNING_OPTIONS,
+        entity_registry_enabled_default=False,
+        value_fn=_service_warning,
     ),
 )
 

--- a/custom_components/polestar_soc/strings.json
+++ b/custom_components/polestar_soc/strings.json
@@ -76,6 +76,27 @@
       },
       "unavailable_reason": {
         "name": "Unavailable reason"
+      },
+      "front_left_tyre_pressure": {
+        "name": "Front left tyre pressure"
+      },
+      "front_right_tyre_pressure": {
+        "name": "Front right tyre pressure"
+      },
+      "rear_left_tyre_pressure": {
+        "name": "Rear left tyre pressure"
+      },
+      "rear_right_tyre_pressure": {
+        "name": "Rear right tyre pressure"
+      },
+      "days_to_service": {
+        "name": "Days to service"
+      },
+      "distance_to_service": {
+        "name": "Distance to service"
+      },
+      "service_warning": {
+        "name": "Service warning"
       }
     },
     "number": {
@@ -192,6 +213,96 @@
       },
       "alarm": {
         "name": "Alarm"
+      },
+      "front_left_tyre_pressure_warning": {
+        "name": "Front left tyre pressure warning"
+      },
+      "front_right_tyre_pressure_warning": {
+        "name": "Front right tyre pressure warning"
+      },
+      "rear_left_tyre_pressure_warning": {
+        "name": "Rear left tyre pressure warning"
+      },
+      "rear_right_tyre_pressure_warning": {
+        "name": "Rear right tyre pressure warning"
+      },
+      "washer_fluid_level_warning": {
+        "name": "Washer fluid level"
+      },
+      "low_voltage_battery_warning": {
+        "name": "12V battery"
+      },
+      "brake_fluid_level_warning": {
+        "name": "Brake fluid level"
+      },
+      "engine_coolant_level_warning": {
+        "name": "Engine coolant level"
+      },
+      "oil_level_warning": {
+        "name": "Oil level"
+      },
+      "brake_light_left_warning": {
+        "name": "Brake light left"
+      },
+      "brake_light_center_warning": {
+        "name": "Brake light center"
+      },
+      "brake_light_right_warning": {
+        "name": "Brake light right"
+      },
+      "fog_light_front_warning": {
+        "name": "Fog light front"
+      },
+      "fog_light_rear_warning": {
+        "name": "Fog light rear"
+      },
+      "position_light_front_left_warning": {
+        "name": "Position light front left"
+      },
+      "position_light_front_right_warning": {
+        "name": "Position light front right"
+      },
+      "position_light_rear_left_warning": {
+        "name": "Position light rear left"
+      },
+      "position_light_rear_right_warning": {
+        "name": "Position light rear right"
+      },
+      "high_beam_left_warning": {
+        "name": "High beam left"
+      },
+      "high_beam_right_warning": {
+        "name": "High beam right"
+      },
+      "low_beam_left_warning": {
+        "name": "Low beam left"
+      },
+      "low_beam_right_warning": {
+        "name": "Low beam right"
+      },
+      "daytime_running_light_left_warning": {
+        "name": "Daytime running light left"
+      },
+      "daytime_running_light_right_warning": {
+        "name": "Daytime running light right"
+      },
+      "turn_indication_front_left_warning": {
+        "name": "Turn indicator front left"
+      },
+      "turn_indication_front_right_warning": {
+        "name": "Turn indicator front right"
+      },
+      "turn_indication_rear_left_warning": {
+        "name": "Turn indicator rear left"
+      },
+      "turn_indication_rear_right_warning": {
+        "name": "Turn indicator rear right"
+      },
+      "registration_plate_light_warning": {
+        "name": "Registration plate light"
+      },
+      "side_mark_lights_warning": {
+        "name": "Side marker lights"
       }
     }
   }

--- a/custom_components/polestar_soc/translations/en.json
+++ b/custom_components/polestar_soc/translations/en.json
@@ -76,6 +76,27 @@
       },
       "unavailable_reason": {
         "name": "Unavailable reason"
+      },
+      "front_left_tyre_pressure": {
+        "name": "Front left tyre pressure"
+      },
+      "front_right_tyre_pressure": {
+        "name": "Front right tyre pressure"
+      },
+      "rear_left_tyre_pressure": {
+        "name": "Rear left tyre pressure"
+      },
+      "rear_right_tyre_pressure": {
+        "name": "Rear right tyre pressure"
+      },
+      "days_to_service": {
+        "name": "Days to service"
+      },
+      "distance_to_service": {
+        "name": "Distance to service"
+      },
+      "service_warning": {
+        "name": "Service warning"
       }
     },
     "number": {
@@ -192,6 +213,96 @@
       },
       "alarm": {
         "name": "Alarm"
+      },
+      "front_left_tyre_pressure_warning": {
+        "name": "Front left tyre pressure warning"
+      },
+      "front_right_tyre_pressure_warning": {
+        "name": "Front right tyre pressure warning"
+      },
+      "rear_left_tyre_pressure_warning": {
+        "name": "Rear left tyre pressure warning"
+      },
+      "rear_right_tyre_pressure_warning": {
+        "name": "Rear right tyre pressure warning"
+      },
+      "washer_fluid_level_warning": {
+        "name": "Washer fluid level"
+      },
+      "low_voltage_battery_warning": {
+        "name": "12V battery"
+      },
+      "brake_fluid_level_warning": {
+        "name": "Brake fluid level"
+      },
+      "engine_coolant_level_warning": {
+        "name": "Engine coolant level"
+      },
+      "oil_level_warning": {
+        "name": "Oil level"
+      },
+      "brake_light_left_warning": {
+        "name": "Brake light left"
+      },
+      "brake_light_center_warning": {
+        "name": "Brake light center"
+      },
+      "brake_light_right_warning": {
+        "name": "Brake light right"
+      },
+      "fog_light_front_warning": {
+        "name": "Fog light front"
+      },
+      "fog_light_rear_warning": {
+        "name": "Fog light rear"
+      },
+      "position_light_front_left_warning": {
+        "name": "Position light front left"
+      },
+      "position_light_front_right_warning": {
+        "name": "Position light front right"
+      },
+      "position_light_rear_left_warning": {
+        "name": "Position light rear left"
+      },
+      "position_light_rear_right_warning": {
+        "name": "Position light rear right"
+      },
+      "high_beam_left_warning": {
+        "name": "High beam left"
+      },
+      "high_beam_right_warning": {
+        "name": "High beam right"
+      },
+      "low_beam_left_warning": {
+        "name": "Low beam left"
+      },
+      "low_beam_right_warning": {
+        "name": "Low beam right"
+      },
+      "daytime_running_light_left_warning": {
+        "name": "Daytime running light left"
+      },
+      "daytime_running_light_right_warning": {
+        "name": "Daytime running light right"
+      },
+      "turn_indication_front_left_warning": {
+        "name": "Turn indicator front left"
+      },
+      "turn_indication_front_right_warning": {
+        "name": "Turn indicator front right"
+      },
+      "turn_indication_rear_left_warning": {
+        "name": "Turn indicator rear left"
+      },
+      "turn_indication_rear_right_warning": {
+        "name": "Turn indicator rear right"
+      },
+      "registration_plate_light_warning": {
+        "name": "Registration plate light"
+      },
+      "side_mark_lights_warning": {
+        "name": "Side marker lights"
       }
     }
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,6 +164,52 @@ def sample_availability():
 
 
 @pytest.fixture
+def sample_health():
+    """Return a sample health state dict (as returned by CepClient)."""
+    return {
+        "days_to_service": 180,
+        "distance_to_service_km": 12000,
+        "service_warning": 1,
+        "brake_fluid_level_warning": 1,
+        "engine_coolant_level_warning": 1,
+        "oil_level_warning": 1,
+        "front_left_tyre_pressure_warning": 1,
+        "front_right_tyre_pressure_warning": 1,
+        "rear_left_tyre_pressure_warning": 1,
+        "rear_right_tyre_pressure_warning": 1,
+        "washer_fluid_level_warning": 1,
+        "low_voltage_battery_warning": 1,
+        "front_left_tyre_pressure_kpa": 240.0,
+        "front_right_tyre_pressure_kpa": 240.0,
+        "rear_left_tyre_pressure_kpa": 250.0,
+        "rear_right_tyre_pressure_kpa": 250.0,
+        "front_tyres_reference_pressure_kpa": 240.0,
+        "rear_tyres_reference_pressure_kpa": 250.0,
+        "brake_light_left_warning": 1,
+        "brake_light_center_warning": 1,
+        "brake_light_right_warning": 1,
+        "fog_light_front_warning": 1,
+        "fog_light_rear_warning": 1,
+        "position_light_front_left_warning": 1,
+        "position_light_front_right_warning": 1,
+        "position_light_rear_left_warning": 1,
+        "position_light_rear_right_warning": 1,
+        "high_beam_left_warning": 1,
+        "high_beam_right_warning": 1,
+        "low_beam_left_warning": 1,
+        "low_beam_right_warning": 1,
+        "daytime_running_light_left_warning": 1,
+        "daytime_running_light_right_warning": 1,
+        "turn_indication_front_left_warning": 1,
+        "turn_indication_front_right_warning": 1,
+        "turn_indication_rear_left_warning": 1,
+        "turn_indication_rear_right_warning": 1,
+        "registration_plate_light_warning": 1,
+        "side_mark_lights_warning": 1,
+    }
+
+
+@pytest.fixture
 def sample_coordinator_data(
     sample_vehicle,
     sample_battery,
@@ -173,6 +219,7 @@ def sample_coordinator_data(
     sample_location,
     sample_exterior,
     sample_availability,
+    sample_health,
 ):
     """Return a full coordinator data dict combining all sources."""
     vin = sample_vehicle["vin"]
@@ -190,4 +237,5 @@ def sample_coordinator_data(
         "location": {vin: sample_location},
         "exterior": {vin: sample_exterior},
         "availability": {vin: sample_availability},
+        "health": {vin: sample_health},
     }

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -167,12 +167,12 @@ class TestNoneHandling:
 
 class TestDescriptionCounts:
     def test_total_descriptions(self):
-        assert len(BINARY_SENSOR_DESCRIPTIONS) == 14
+        assert len(BINARY_SENSOR_DESCRIPTIONS) == 44
 
     def test_enabled_by_default_count(self):
         enabled = [d for d in BINARY_SENSOR_DESCRIPTIONS if d.entity_registry_enabled_default]
-        assert len(enabled) == 5  # vehicle_available + 4 doors
+        assert len(enabled) == 11  # 5 exterior + 4 tyre warnings + washer fluid + 12V battery
 
     def test_disabled_by_default_count(self):
         disabled = [d for d in BINARY_SENSOR_DESCRIPTIONS if not d.entity_registry_enabled_default]
-        assert len(disabled) == 9  # 4 windows + hood + tailgate + tank_lid + sunroof + alarm
+        assert len(disabled) == 33  # 9 exterior + 3 fluid/oil + 21 light warnings

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -165,6 +165,77 @@ class TestNoneHandling:
         assert sensor.extra_state_attributes is None
 
 
+class TestHealthWarningIsOn:
+    def test_no_warning(self, sample_coordinator_data, sample_vehicle):
+        """NO_WARNING(1) → False (not a problem)."""
+        sensor = _make_sensor(
+            sample_coordinator_data, sample_vehicle, VIN, "front_left_tyre_pressure_warning"
+        )
+        assert sensor.is_on is False
+
+    def test_very_low(self, sample_coordinator_data, sample_vehicle):
+        """VERY_LOW(2) → True (problem)."""
+        sample_coordinator_data["health"][VIN]["front_left_tyre_pressure_warning"] = 2
+        sensor = _make_sensor(
+            sample_coordinator_data, sample_vehicle, VIN, "front_left_tyre_pressure_warning"
+        )
+        assert sensor.is_on is True
+
+    def test_low(self, sample_coordinator_data, sample_vehicle):
+        """LOW(3) → True (problem)."""
+        sample_coordinator_data["health"][VIN]["rear_right_tyre_pressure_warning"] = 3
+        sensor = _make_sensor(
+            sample_coordinator_data, sample_vehicle, VIN, "rear_right_tyre_pressure_warning"
+        )
+        assert sensor.is_on is True
+
+    def test_missing_health_data(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["health"] = {}
+        sensor = _make_sensor(
+            sample_coordinator_data, sample_vehicle, VIN, "front_left_tyre_pressure_warning"
+        )
+        assert sensor.is_on is None
+
+    def test_tyre_warning_extra_attrs(self, sample_coordinator_data, sample_vehicle):
+        sample_coordinator_data["health"][VIN]["front_left_tyre_pressure_warning"] = 2
+        sensor = _make_sensor(
+            sample_coordinator_data, sample_vehicle, VIN, "front_left_tyre_pressure_warning"
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["raw_state"] == "Very low"
+        assert attrs["pressure_kpa"] == 240.0
+
+    def test_exact_match_washer_fluid(self, sample_coordinator_data, sample_vehicle):
+        """Washer fluid uses exact match: 2=Too low → True."""
+        sample_coordinator_data["health"][VIN]["washer_fluid_level_warning"] = 2
+        sensor = _make_sensor(
+            sample_coordinator_data, sample_vehicle, VIN, "washer_fluid_level_warning"
+        )
+        assert sensor.is_on is True
+
+    def test_exact_match_washer_fluid_no_warning(self, sample_coordinator_data, sample_vehicle):
+        """Washer fluid NO_WARNING(1) → False."""
+        sensor = _make_sensor(
+            sample_coordinator_data, sample_vehicle, VIN, "washer_fluid_level_warning"
+        )
+        assert sensor.is_on is False
+
+    def test_light_failure(self, sample_coordinator_data, sample_vehicle):
+        """Light FAILURE(2) → True."""
+        sample_coordinator_data["health"][VIN]["brake_light_center_warning"] = 2
+        sensor = _make_sensor(
+            sample_coordinator_data, sample_vehicle, VIN, "brake_light_center_warning"
+        )
+        assert sensor.is_on is True
+
+    def test_light_no_warning(self, sample_coordinator_data, sample_vehicle):
+        """Light NO_WARNING(1) → False."""
+        sensor = _make_sensor(
+            sample_coordinator_data, sample_vehicle, VIN, "brake_light_center_warning"
+        )
+        assert sensor.is_on is False
+
+
 class TestDescriptionCounts:
     def test_total_descriptions(self):
         assert len(BINARY_SENSOR_DESCRIPTIONS) == 44

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -585,6 +585,17 @@ class TestParseHealthResponse:
         assert result["washer_fluid_level_warning"] is None
         assert result["low_voltage_battery_warning"] is None
 
+    def test_zero_days_to_service_is_not_none(self):
+        """days_to_service=0 should return 0, not None."""
+        payload = _build_health_payload(
+            TEST_VIN,
+            varint_fields={3: 0, 4: 0},
+            float_fields={},
+        )
+        result = _parse_health_response(payload)
+        assert result["days_to_service"] == 0
+        assert result["distance_to_service_km"] == 0
+
     def test_pressure_rounding(self):
         """Verify tyre pressure values are rounded to 1 decimal."""
         payload = _build_health_payload(

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -13,11 +13,13 @@ from custom_components.polestar_soc.cep import (
     _parse_battery_response,
     _parse_climate_response,
     _parse_exterior_response,
+    _parse_health_response,
     _parse_location_response,
 )
 from custom_components.polestar_soc.proto import (
     _decode_message,
     _encode_field_bytes,
+    _encode_field_fixed32,
     _encode_field_varint,
     _get_submessage,
 )
@@ -430,3 +432,169 @@ class TestParseAvailabilityResponse:
         state = _get_submessage(outer, 3)
         assert state is not None
         assert 3 in state  # availability_status field
+
+
+# ---------------------------------------------------------------------------
+# Health tests
+# ---------------------------------------------------------------------------
+
+
+def _build_health_state(varint_fields: dict[int, int], float_fields: dict[int, float]) -> bytes:
+    """Build a Health sub-message from varint and float (fixed32) fields."""
+    data = b""
+    for field_num in sorted(varint_fields):
+        data += _encode_field_varint(field_num, varint_fields[field_num])
+    for field_num in sorted(float_fields):
+        data += _encode_field_fixed32(field_num, float_fields[field_num])
+    return data
+
+
+def _build_health_payload(
+    vin: str, varint_fields: dict[int, int], float_fields: dict[int, float]
+) -> bytes:
+    """Build a synthetic GetHealth response with two-level envelope."""
+    state_bytes = _build_health_state(varint_fields, float_fields)
+    data = _encode_field_bytes(2, vin.encode("utf-8"))
+    data += _encode_field_bytes(3, state_bytes)
+    return data
+
+
+# Full health response: service info, tyre warnings, fluid warnings, pressures
+HEALTH_FULL = _build_health_payload(
+    TEST_VIN,
+    varint_fields={
+        3: 180,    # days_to_service
+        4: 12000,  # distance_to_service_km
+        5: 1,      # service_warning: NO_WARNING
+        6: 1,      # brake_fluid_level_warning: NO_WARNING
+        7: 1,      # engine_coolant_level_warning: NO_WARNING
+        8: 1,      # oil_level_warning: NO_WARNING
+        9: 1,      # front_left_tyre_pressure_warning: NO_WARNING
+        10: 3,     # front_right_tyre_pressure_warning: LOW
+        11: 1,     # rear_left_tyre_pressure_warning: NO_WARNING
+        12: 2,     # rear_right_tyre_pressure_warning: VERY_LOW
+        13: 1,     # washer_fluid_level_warning: NO_WARNING
+        14: 1,     # brake_light_left_warning: NO_WARNING
+        15: 2,     # brake_light_center_warning: FAILURE
+        38: 1,     # low_voltage_battery_warning: NO_WARNING
+    },
+    float_fields={
+        39: 240.0,  # front_left_tyre_pressure_kpa
+        40: 210.5,  # front_right_tyre_pressure_kpa
+        41: 245.0,  # rear_left_tyre_pressure_kpa
+        42: 190.3,  # rear_right_tyre_pressure_kpa
+        43: 240.0,  # front_tyres_reference_pressure_kpa
+        44: 250.0,  # rear_tyres_reference_pressure_kpa
+    },
+)
+
+# Minimal: only tyre pressures, no warnings set
+HEALTH_MINIMAL = _build_health_payload(
+    TEST_VIN,
+    varint_fields={},
+    float_fields={
+        39: 235.0,
+        40: 235.0,
+        41: 250.0,
+        42: 250.0,
+    },
+)
+
+
+class TestParseHealthResponse:
+    def test_full_response(self):
+        result = _parse_health_response(HEALTH_FULL)
+        # Service info
+        assert result["days_to_service"] == 180
+        assert result["distance_to_service_km"] == 12000
+        assert result["service_warning"] == 1  # NO_WARNING
+        # Fluid warnings
+        assert result["brake_fluid_level_warning"] == 1  # NO_WARNING
+        assert result["engine_coolant_level_warning"] == 1  # NO_WARNING
+        assert result["oil_level_warning"] == 1  # NO_WARNING
+        assert result["washer_fluid_level_warning"] == 1  # NO_WARNING
+        # Tyre pressure warnings
+        assert result["front_left_tyre_pressure_warning"] == 1  # NO_WARNING
+        assert result["front_right_tyre_pressure_warning"] == 3  # LOW
+        assert result["rear_left_tyre_pressure_warning"] == 1  # NO_WARNING
+        assert result["rear_right_tyre_pressure_warning"] == 2  # VERY_LOW
+        # 12V battery
+        assert result["low_voltage_battery_warning"] == 1  # NO_WARNING
+        # Light warnings
+        assert result["brake_light_left_warning"] == 1  # NO_WARNING
+        assert result["brake_light_center_warning"] == 2  # FAILURE
+
+    def test_tyre_pressure_floats(self):
+        result = _parse_health_response(HEALTH_FULL)
+        assert result["front_left_tyre_pressure_kpa"] == pytest.approx(240.0, abs=0.2)
+        assert result["front_right_tyre_pressure_kpa"] == pytest.approx(210.5, abs=0.2)
+        assert result["rear_left_tyre_pressure_kpa"] == pytest.approx(245.0, abs=0.2)
+        assert result["rear_right_tyre_pressure_kpa"] == pytest.approx(190.3, abs=0.2)
+        assert result["front_tyres_reference_pressure_kpa"] == pytest.approx(240.0, abs=0.2)
+        assert result["rear_tyres_reference_pressure_kpa"] == pytest.approx(250.0, abs=0.2)
+
+    def test_minimal_response_missing_warnings(self):
+        """Response with only float fields returns None for varint warnings."""
+        result = _parse_health_response(HEALTH_MINIMAL)
+        assert result["front_left_tyre_pressure_kpa"] == pytest.approx(235.0, abs=0.2)
+        assert result["days_to_service"] is None
+        assert result["service_warning"] is None
+        assert result["front_left_tyre_pressure_warning"] is None
+        assert result["washer_fluid_level_warning"] is None
+        assert result["low_voltage_battery_warning"] is None
+
+    def test_empty_response(self):
+        result = _parse_health_response(b"")
+        assert result["front_left_tyre_pressure_kpa"] is None
+        assert result["rear_right_tyre_pressure_kpa"] is None
+        assert result["days_to_service"] is None
+        assert result["service_warning"] is None
+        assert result["front_left_tyre_pressure_warning"] is None
+        assert result["washer_fluid_level_warning"] is None
+        assert result["low_voltage_battery_warning"] is None
+        assert result["brake_light_left_warning"] is None
+        assert result["front_tyres_reference_pressure_kpa"] is None
+
+    def test_missing_state_submessage(self):
+        """Response with VIN but no field 3 returns all None."""
+        data = _encode_field_bytes(2, TEST_VIN.encode("utf-8"))
+        result = _parse_health_response(data)
+        assert result["front_left_tyre_pressure_kpa"] is None
+        assert result["days_to_service"] is None
+        assert result["front_left_tyre_pressure_warning"] is None
+
+    def test_two_level_envelope(self):
+        """Verify outer envelope has field 2=VIN and field 3=Health state."""
+        outer = _decode_message(HEALTH_FULL)
+        assert outer[2][0] == TEST_VIN.encode("utf-8")
+        assert isinstance(outer[3][0], (bytes, bytearray))
+        state = _get_submessage(outer, 3)
+        assert state is not None
+        assert 3 in state  # days_to_service field
+
+    def test_unspecified_enum_returns_none(self):
+        """Enum value 0 (UNSPECIFIED) returns None."""
+        payload = _build_health_payload(
+            TEST_VIN,
+            varint_fields={5: 0, 9: 0, 13: 0, 38: 0},
+            float_fields={},
+        )
+        result = _parse_health_response(payload)
+        assert result["service_warning"] is None
+        assert result["front_left_tyre_pressure_warning"] is None
+        assert result["washer_fluid_level_warning"] is None
+        assert result["low_voltage_battery_warning"] is None
+
+    def test_pressure_rounding(self):
+        """Verify tyre pressure values are rounded to 1 decimal."""
+        payload = _build_health_payload(
+            TEST_VIN,
+            varint_fields={},
+            float_fields={39: 240.123},
+        )
+        result = _parse_health_response(payload)
+        # IEEE 754 single-precision may not store 240.123 exactly,
+        # but the result should be rounded to 1 decimal place
+        val = result["front_left_tyre_pressure_kpa"]
+        assert val is not None
+        assert val == round(val, 1)

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -463,20 +463,20 @@ def _build_health_payload(
 HEALTH_FULL = _build_health_payload(
     TEST_VIN,
     varint_fields={
-        3: 180,    # days_to_service
+        3: 180,  # days_to_service
         4: 12000,  # distance_to_service_km
-        5: 1,      # service_warning: NO_WARNING
-        6: 1,      # brake_fluid_level_warning: NO_WARNING
-        7: 1,      # engine_coolant_level_warning: NO_WARNING
-        8: 1,      # oil_level_warning: NO_WARNING
-        9: 1,      # front_left_tyre_pressure_warning: NO_WARNING
-        10: 3,     # front_right_tyre_pressure_warning: LOW
-        11: 1,     # rear_left_tyre_pressure_warning: NO_WARNING
-        12: 2,     # rear_right_tyre_pressure_warning: VERY_LOW
-        13: 1,     # washer_fluid_level_warning: NO_WARNING
-        14: 1,     # brake_light_left_warning: NO_WARNING
-        15: 2,     # brake_light_center_warning: FAILURE
-        38: 1,     # low_voltage_battery_warning: NO_WARNING
+        5: 1,  # service_warning: NO_WARNING
+        6: 1,  # brake_fluid_level_warning: NO_WARNING
+        7: 1,  # engine_coolant_level_warning: NO_WARNING
+        8: 1,  # oil_level_warning: NO_WARNING
+        9: 1,  # front_left_tyre_pressure_warning: NO_WARNING
+        10: 3,  # front_right_tyre_pressure_warning: LOW
+        11: 1,  # rear_left_tyre_pressure_warning: NO_WARNING
+        12: 2,  # rear_right_tyre_pressure_warning: VERY_LOW
+        13: 1,  # washer_fluid_level_warning: NO_WARNING
+        14: 1,  # brake_light_left_warning: NO_WARNING
+        15: 2,  # brake_light_center_warning: FAILURE
+        38: 1,  # low_voltage_battery_warning: NO_WARNING
     },
     float_fields={
         39: 240.0,  # front_left_tyre_pressure_kpa


### PR DESCRIPTION
## Summary
- Fetch vehicle health data from CEP `HealthService/GetHealth` (streaming RPC — first streaming read on CEP)
- Add 7 sensor entities: 4x tyre pressure (kPa), days to service, distance to service, service warning
- Add 30 binary sensor entities: 4x tyre pressure warnings, washer fluid, 12V battery, brake fluid, engine coolant, oil level, 21x light failure warnings
- 10 entities enabled by default, 27 disabled by default to avoid entity bloat

## Test plan
- [x] Unit tests: 8 new health parser tests, all 316 tests pass
- [x] Live tested against real vehicle via `scripts/test_health_live.py`
- [ ] Install in HA and verify entities appear correctly