### PR TITLE
Add vehicle health and battery/charging entities

### DIFF
--- a/custom_components/polestar_soc/binary_sensor.py
+++ b/custom_components/polestar_soc/binary_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ALARM_STATUS_MAP,
+    CHARGER_CONNECTION_STATUS_MAP,
     DOMAIN,
     EXTERIOR_LIGHT_WARNING_MAP,
     FLUID_WARNING_MAP,
@@ -90,6 +91,34 @@ def _availability_extra_attrs(data: dict, vin: str) -> dict | None:
     reason_val = availability.get("unavailable_reason")
     reason = UNAVAILABLE_REASON_MAP.get(reason_val) if reason_val else None
     return {"unavailable_reason": reason}
+
+
+# ---------------------------------------------------------------------------
+# Charger connected helpers
+# ---------------------------------------------------------------------------
+
+
+def _charger_connected_is_on(data: dict, vin: str) -> bool | None:
+    """Charger connected: True=Plugged in, False=Unplugged, None=Unknown."""
+    cep_battery = data.get("cep_battery", {}).get(vin)
+    if cep_battery is None:
+        return None
+    val = cep_battery.get("charger_connection_status")
+    if val is None:
+        return None
+    return val != 2  # True for CONNECTED(1) and FAULT(3), False for DISCONNECTED(2)
+
+
+def _charger_connected_extra_attrs(data: dict, vin: str) -> dict | None:
+    """Return charger connection status as an extra attribute."""
+    cep_battery = data.get("cep_battery", {}).get(vin)
+    if cep_battery is None:
+        return None
+    val = cep_battery.get("charger_connection_status")
+    if val is None:
+        return None
+    label = CHARGER_CONNECTION_STATUS_MAP.get(val, f"Unknown ({val})")
+    return {"raw_state": label}
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +217,13 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[PolestarBinarySensorDescription, ...] = (
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         is_on_fn=_availability_is_on,
         extra_attrs_fn=_availability_extra_attrs,
+    ),
+    PolestarBinarySensorDescription(
+        key="charger_connected",
+        translation_key="charger_connected",
+        device_class=BinarySensorDeviceClass.PLUG,
+        is_on_fn=_charger_connected_is_on,
+        extra_attrs_fn=_charger_connected_extra_attrs,
     ),
     PolestarBinarySensorDescription(
         key="front_left_door",

--- a/custom_components/polestar_soc/cep.py
+++ b/custom_components/polestar_soc/cep.py
@@ -178,6 +178,7 @@ def _parse_battery_response(data: bytes) -> dict:
         "estimated_charging_time_minutes": None,
         "estimated_range_miles": None,
         "charging_power_watts": None,
+        "charging_type": None,
         "raw_fields": {},
     }
     if not data:
@@ -203,6 +204,7 @@ def _parse_battery_response(data: bytes) -> dict:
         "estimated_charging_time_minutes": _get_int(state, 5) or None,
         "estimated_range_miles": _get_int(state, 8) or None,
         "charging_power_watts": _get_int(state, 10) or None,
+        "charging_type": _get_int(state, 17) or None,
         "raw_fields": raw_fields,
     }
 

--- a/custom_components/polestar_soc/const.py
+++ b/custom_components/polestar_soc/const.py
@@ -195,6 +195,20 @@ EXTERIOR_LIGHT_WARNING_MAP: dict[int, str | None] = {
     2: "Failure",
 }
 
+# CEP Battery enums
+CHARGER_CONNECTION_STATUS_MAP: dict[int, str] = {
+    1: "Connected",
+    2: "Disconnected",
+    3: "Fault",
+}
+
+CHARGING_TYPE_MAP: dict[int, str] = {
+    1: "Not charging",
+    2: "AC",
+    3: "DC",
+    4: "Wireless",
+}
+
 # Weekday enum (ParkingClimateTimer)
 WEEKDAY_MAP: dict[int, str] = {
     1: "Monday",

--- a/custom_components/polestar_soc/sensor.py
+++ b/custom_components/polestar_soc/sensor.py
@@ -12,13 +12,14 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfPressure, UnitOfTime
+from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfPower, UnitOfPressure, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
+    CHARGING_TYPE_MAP,
     CLIMATE_RUNNING_STATUS_MAP,
     DOMAIN,
     HEATING_INTENSITY_MAP,
@@ -118,6 +119,30 @@ def _estimated_range(data: dict, vin: str) -> int | None:
     return cep_battery.get("estimated_range_km")
 
 
+def _charging_power(data: dict, vin: str) -> int | None:
+    cep_battery = data.get("cep_battery", {}).get(vin)
+    if cep_battery is None:
+        return None
+    return cep_battery.get("charging_power_watts")
+
+
+def _charging_type(data: dict, vin: str) -> str | None:
+    cep_battery = data.get("cep_battery", {}).get(vin)
+    if cep_battery is None:
+        return None
+    val = cep_battery.get("charging_type")
+    if val is None:
+        return None
+    return CHARGING_TYPE_MAP.get(val)
+
+
+def _estimated_range_miles(data: dict, vin: str) -> int | None:
+    cep_battery = data.get("cep_battery", {}).get(vin)
+    if cep_battery is None:
+        return None
+    return cep_battery.get("estimated_range_miles")
+
+
 def _health_pressure(key: str) -> Callable[[dict, str], float | None]:
     """Create a value_fn for a tyre pressure sensor (kPa)."""
 
@@ -158,6 +183,7 @@ _HEATING_INTENSITY_OPTIONS = list(HEATING_INTENSITY_MAP.values())
 _USAGE_MODE_OPTIONS = list(USAGE_MODE_MAP.values())
 _UNAVAILABLE_REASON_OPTIONS = list(UNAVAILABLE_REASON_MAP.values())
 _SERVICE_WARNING_OPTIONS = list(SERVICE_WARNING_MAP.values())
+_CHARGING_TYPE_OPTIONS = list(CHARGING_TYPE_MAP.values())
 
 SENSOR_DESCRIPTIONS: tuple[PolestarSensorDescription, ...] = (
     PolestarSensorDescription(
@@ -238,6 +264,30 @@ SENSOR_DESCRIPTIONS: tuple[PolestarSensorDescription, ...] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=_estimated_range,
+    ),
+    PolestarSensorDescription(
+        key="charging_power",
+        translation_key="charging_power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_charging_power,
+    ),
+    PolestarSensorDescription(
+        key="charging_type",
+        translation_key="charging_type",
+        device_class=SensorDeviceClass.ENUM,
+        options=_CHARGING_TYPE_OPTIONS,
+        value_fn=_charging_type,
+    ),
+    PolestarSensorDescription(
+        key="estimated_range_miles",
+        translation_key="estimated_range_miles",
+        native_unit_of_measurement=UnitOfLength.MILES,
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        value_fn=_estimated_range_miles,
     ),
     PolestarSensorDescription(
         key="usage_mode",

--- a/custom_components/polestar_soc/strings.json
+++ b/custom_components/polestar_soc/strings.json
@@ -97,6 +97,15 @@
       },
       "service_warning": {
         "name": "Service warning"
+      },
+      "charging_power": {
+        "name": "Charging power"
+      },
+      "charging_type": {
+        "name": "Charging type"
+      },
+      "estimated_range_miles": {
+        "name": "Estimated range (miles)"
       }
     },
     "number": {
@@ -303,6 +312,9 @@
       },
       "side_mark_lights_warning": {
         "name": "Side marker lights"
+      },
+      "charger_connected": {
+        "name": "Charger connected"
       }
     }
   }

--- a/custom_components/polestar_soc/translations/en.json
+++ b/custom_components/polestar_soc/translations/en.json
@@ -97,6 +97,15 @@
       },
       "service_warning": {
         "name": "Service warning"
+      },
+      "charging_power": {
+        "name": "Charging power"
+      },
+      "charging_type": {
+        "name": "Charging type"
+      },
+      "estimated_range_miles": {
+        "name": "Estimated range (miles)"
       }
     },
     "number": {
@@ -303,6 +312,9 @@
       },
       "side_mark_lights_warning": {
         "name": "Side marker lights"
+      },
+      "charger_connected": {
+        "name": "Charger connected"
       }
     }
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,7 @@ def sample_cep_battery():
         "estimated_charging_time_minutes": None,
         "estimated_range_miles": 140,
         "charging_power_watts": None,
+        "charging_type": 1,
         "raw_fields": {},
     }
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -238,11 +238,11 @@ class TestHealthWarningIsOn:
 
 class TestDescriptionCounts:
     def test_total_descriptions(self):
-        assert len(BINARY_SENSOR_DESCRIPTIONS) == 44
+        assert len(BINARY_SENSOR_DESCRIPTIONS) == 45
 
     def test_enabled_by_default_count(self):
         enabled = [d for d in BINARY_SENSOR_DESCRIPTIONS if d.entity_registry_enabled_default]
-        assert len(enabled) == 11  # 5 exterior + 4 tyre warnings + washer fluid + 12V battery
+        assert len(enabled) == 12  # 5 exterior + charger + 4 tyre + washer + 12V
 
     def test_disabled_by_default_count(self):
         disabled = [d for d in BINARY_SENSOR_DESCRIPTIONS if not d.entity_registry_enabled_default]

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -105,6 +105,7 @@ class TestParseBatteryResponse:
         assert result["estimated_charging_time_minutes"] is None  # field 5 = 0
         assert result["estimated_range_miles"] == 140
         assert result["charging_power_watts"] is None  # field 10 not in payload
+        assert result["charging_type"] == 1  # NONE (not charging)
 
     def test_raw_fields(self):
         result = _parse_battery_response(BATTERY_PAYLOAD)
@@ -124,6 +125,7 @@ class TestParseBatteryResponse:
         assert result["charging_status"] is None
         assert result["charger_connection_status"] is None
         assert result["charging_power_watts"] is None
+        assert result["charging_type"] is None
         assert result["raw_fields"] == {}
 
     def test_two_level_decode(self):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,11 +2,14 @@
 
 from custom_components.polestar_soc.sensor import (
     _battery_soc,
+    _charging_power,
     _charging_status,
     _charging_time_remaining,
+    _charging_type,
     _climate_heating,
     _climate_status,
     _estimated_range,
+    _estimated_range_miles,
     _odometer_km,
 )
 
@@ -171,3 +174,66 @@ class TestEstimatedRange:
     def test_none_when_range_missing(self):
         data = {"cep_battery": {VIN: {"soc": 76.0}}}
         assert _estimated_range(data, VIN) is None
+
+
+# ---------------------------------------------------------------------------
+# Battery/charging sensors (CEP)
+# ---------------------------------------------------------------------------
+
+
+class TestChargingPower:
+    def test_returns_watts(self):
+        data = {"cep_battery": {VIN: {"charging_power_watts": 11000}}}
+        assert _charging_power(data, VIN) == 11000
+
+    def test_none_when_not_charging(self, sample_coordinator_data):
+        # Fixture has charging_power_watts=None (not charging)
+        assert _charging_power(sample_coordinator_data, VIN) is None
+
+    def test_none_when_no_cep_battery(self):
+        assert _charging_power({}, VIN) is None
+
+    def test_none_when_missing_key(self):
+        data = {"cep_battery": {VIN: {"soc": 76.0}}}
+        assert _charging_power(data, VIN) is None
+
+
+class TestChargingType:
+    def test_not_charging(self, sample_coordinator_data):
+        # Fixture has charging_type=1 (NONE)
+        assert _charging_type(sample_coordinator_data, VIN) == "Not charging"
+
+    def test_ac(self):
+        data = {"cep_battery": {VIN: {"charging_type": 2}}}
+        assert _charging_type(data, VIN) == "AC"
+
+    def test_dc(self):
+        data = {"cep_battery": {VIN: {"charging_type": 3}}}
+        assert _charging_type(data, VIN) == "DC"
+
+    def test_wireless(self):
+        data = {"cep_battery": {VIN: {"charging_type": 4}}}
+        assert _charging_type(data, VIN) == "Wireless"
+
+    def test_none_when_no_cep_battery(self):
+        assert _charging_type({}, VIN) is None
+
+    def test_none_when_missing_key(self):
+        data = {"cep_battery": {VIN: {"soc": 76.0}}}
+        assert _charging_type(data, VIN) is None
+
+    def test_unknown_value_returns_none(self):
+        data = {"cep_battery": {VIN: {"charging_type": 99}}}
+        assert _charging_type(data, VIN) is None
+
+
+class TestEstimatedRangeMiles:
+    def test_returns_miles(self, sample_coordinator_data):
+        assert _estimated_range_miles(sample_coordinator_data, VIN) == 140
+
+    def test_none_when_no_cep_battery(self):
+        assert _estimated_range_miles({}, VIN) is None
+
+    def test_none_when_missing_key(self):
+        data = {"cep_battery": {VIN: {"soc": 76.0}}}
+        assert _estimated_range_miles(data, VIN) is None


### PR DESCRIPTION
## Summary

- Add vehicle health entities: tyre pressure sensors, fluid level warnings, service info, light warnings
- Add battery/charging entities: charging power (W), charging type (AC/DC/Wireless), charger connected (plug binary sensor), estimated range in miles
- Fix health parser treating 0 days/distance to service as None

## New entities

### Health (from CEP HealthService)
- 4 tyre pressure sensors (kPa)
- 4 tyre pressure warning binary sensors
- Washer fluid, brake fluid, engine coolant, oil level warnings
- 12V battery warning
- Days/distance to service, service warning
- 21 exterior light warning binary sensors (disabled by default)

### Battery/charging (from CEP BatteryService)
- **Charging power** — watts, shows current charging power
- **Charging type** — enum: AC / DC / Wireless / Not charging
- **Charger connected** — binary sensor with PLUG device class
- **Estimated range (miles)** — disabled by default (km version already exists)

## Notes

- No new API calls — all data was already fetched by the coordinator
- `charging_type` field extracted from existing battery response (was only in raw_fields)
- Miles range sensor disabled by default since HA can convert units from the km sensor

## Test plan

- [x] All 340 unit tests pass
- [x] Ruff lint and format clean
- [x] Verified against live API — all new fields parsed correctly