### PR TITLE
Fix OTP 2FA: include CSRF tokens in OTP and continue submissions

### DIFF
--- a/custom_components/polestar_soc/coordinator.py
+++ b/custom_components/polestar_soc/coordinator.py
@@ -139,13 +139,28 @@ class PolestarAPI:
         session: requests.Session,
         otp_resume: str,
         otp_code: str,
+        csrf_token: str = "",
     ) -> requests.Response:
-        """Submit OTP code and handle the success-form continuation."""
+        """Submit OTP code and handle the success-form continuation.
+
+        The PingFederate OTP page requires a CSRF token alongside the OTP
+        code.  The success page that follows also contains its own CSRF
+        token which must be sent with the continuation POST.
+        """
+        otp_data: dict[str, str] = {"otp": otp_code}
+        if csrf_token:
+            otp_data["cSRFToken"] = csrf_token
         resp = session.post(
             otp_resume,
-            data={"otp": otp_code},
+            data=otp_data,
             allow_redirects=False,
             timeout=HTTP_TIMEOUT,
+        )
+        _LOGGER.debug(
+            "OTP submit response: status=%s, location=%s, has_success_form=%s",
+            resp.status_code,
+            resp.headers.get("Location", ""),
+            "otp-success-form" in resp.text,
         )
         # OTP success returns a page with auto-submit form
         if "otp-success-form" in resp.text:
@@ -154,11 +169,24 @@ class PolestarAPI:
                 resp.text,
             )
             continue_url = OIDC_BASE_URL + action_match.group(1) if action_match else otp_resume
+            # Extract the CSRF token from the success page
+            continue_csrf = ""
+            csrf_match = re.search(r'name="cSRFToken"\s+value="([^"]+)"', resp.text)
+            if csrf_match:
+                continue_csrf = csrf_match.group(1)
+            continue_data: dict[str, str] = {"continue.authentication": "true"}
+            if continue_csrf:
+                continue_data["cSRFToken"] = continue_csrf
             resp = session.post(
                 continue_url,
-                data={"continue.authentication": "true"},
+                data=continue_data,
                 allow_redirects=False,
                 timeout=HTTP_TIMEOUT,
+            )
+            _LOGGER.debug(
+                "OTP continue response: status=%s, location=%s",
+                resp.status_code,
+                resp.headers.get("Location", ""),
             )
         return resp
 
@@ -172,6 +200,14 @@ class PolestarAPI:
         redirect_url = resp.headers.get("Location", "")
         parsed = urlparse(redirect_url)
         params = parse_qs(parsed.query)
+
+        # Check for error in redirect (e.g. failed OTP returns
+        # polestar-explore://...?error=access_denied)
+        if "error" in params:
+            error = params["error"][0]
+            error_desc = params.get("error_description", [""])[0]
+            _LOGGER.debug("Auth redirect contains error: %s (%s)", error, error_desc)
+            raise UpdateFailed(f"Authentication failed: {error_desc or error}")
 
         # Handle consent/confirmation
         if "code" not in params and "uid" in params:
@@ -189,7 +225,8 @@ class PolestarAPI:
             parsed = urlparse(redirect_url)
             params = parse_qs(parsed.query)
 
-        if "code" not in params:
+        # Only follow redirect if it is an HTTP(S) URL
+        if "code" not in params and parsed.scheme in ("http", "https"):
             resp = session.get(redirect_url, allow_redirects=False, timeout=HTTP_TIMEOUT)
             if resp.status_code in (302, 303):
                 redirect_url = resp.headers.get("Location", "")
@@ -197,6 +234,7 @@ class PolestarAPI:
                 params = parse_qs(parsed.query)
 
         if "code" not in params:
+            _LOGGER.debug("No auth code in redirect URL: %s", redirect_url)
             raise UpdateFailed("No authorization code received")
 
         return params["code"][0]
@@ -231,10 +269,11 @@ class PolestarAPI:
         return tokens
 
     @staticmethod
-    def _detect_otp_challenge(resp: requests.Response, resume_url: str) -> str | None:
+    def _detect_otp_challenge(resp: requests.Response, resume_url: str) -> tuple[str, str] | None:
         """Check if a credential-POST response is a 2FA challenge.
 
-        Returns the OTP resume URL if 2FA is required, or None.
+        Returns ``(otp_resume_url, csrf_token)`` if 2FA is required,
+        or ``None``.
         """
         if resp.status_code in (302, 303):
             return None  # No 2FA — redirect means success
@@ -247,8 +286,23 @@ class PolestarAPI:
             resp.text,
         )
         if not action_match:
+            # Try HTML form action attribute as fallback
+            action_match = re.search(
+                r'action="(/as/[^"]+/resume/as/authorization\.ping)"',
+                resp.text,
+            )
+        if not action_match:
             return None
-        return OIDC_BASE_URL + action_match.group(1)
+        otp_url = OIDC_BASE_URL + action_match.group(1)
+        # Extract CSRF token from the OTP challenge page
+        csrf_match = re.search(r'cSRFToken:\s*"([^"]+)"', resp.text)
+        csrf_token = csrf_match.group(1) if csrf_match else ""
+        _LOGGER.debug(
+            "OTP challenge detected: url=%s, has_csrf=%s",
+            otp_url,
+            bool(csrf_token),
+        )
+        return otp_url, csrf_token
 
     # -- Public login methods ------------------------------------------------
 
@@ -268,14 +322,15 @@ class PolestarAPI:
                 raise ConfigEntryAuthFailed("Invalid email or password")
 
             # 2SV: server returned OTP challenge page (200 with form)
-            otp_resume = self._detect_otp_challenge(resp, resume_url)
-            if otp_resume:
+            otp_result = self._detect_otp_challenge(resp, resume_url)
+            if otp_result:
+                otp_resume, csrf_token = otp_result
                 otp_code = self._get_otp_code()
                 if not otp_code:
                     raise UpdateFailed("2FA code required but not provided")
 
                 _LOGGER.debug("Submitting OTP to %s", otp_resume)
-                resp = self._submit_otp(session, otp_resume, otp_code)
+                resp = self._submit_otp(session, otp_resume, otp_code, csrf_token)
 
                 if resp.status_code not in (302, 303):
                     raise UpdateFailed(f"2FA verification failed ({resp.status_code})")
@@ -306,8 +361,9 @@ class PolestarAPI:
             if "ERR001" in resp.text or "authMessage" in resp.text:
                 raise ConfigEntryAuthFailed("Invalid email or password")
 
-            otp_resume = self._detect_otp_challenge(resp, resume_url)
-            if otp_resume:
+            otp_result = self._detect_otp_challenge(resp, resume_url)
+            if otp_result:
+                otp_resume, csrf_token = otp_result
                 # 2FA triggered — return session state for the caller to
                 # collect the OTP code and call login_complete_2fa().
                 return {
@@ -315,6 +371,7 @@ class PolestarAPI:
                     "_session_state": {
                         "session": session,
                         "otp_resume": otp_resume,
+                        "csrf_token": csrf_token,
                         "resume_url": resume_url,
                         "code_verifier": code_verifier,
                     },
@@ -334,11 +391,12 @@ class PolestarAPI:
         """
         session: requests.Session = session_state["session"]
         otp_resume: str = session_state["otp_resume"]
+        csrf_token: str = session_state.get("csrf_token", "")
         resume_url: str = session_state["resume_url"]
         code_verifier: str = session_state["code_verifier"]
 
         _LOGGER.debug("Submitting OTP to %s", otp_resume)
-        resp = self._submit_otp(session, otp_resume, otp_code)
+        resp = self._submit_otp(session, otp_resume, otp_code, csrf_token)
 
         if resp.status_code not in (302, 303):
             raise UpdateFailed(f"2FA verification failed ({resp.status_code})")

--- a/test_otp.py
+++ b/test_otp.py
@@ -1,0 +1,176 @@
+"""Local test script for Polestar PCCS 2FA OTP flow."""
+import base64
+import getpass
+import hashlib
+import os
+import re
+import sys
+from urllib.parse import parse_qs, urlparse
+
+import requests
+
+OIDC_BASE_URL = "https://polestarid.eu.polestar.com"
+OIDC_AUTH_URL = f"{OIDC_BASE_URL}/as/authorization.oauth2"
+OIDC_TOKEN_URL = f"{OIDC_BASE_URL}/as/token.oauth2"
+
+PCCS_CLIENT_ID = "lp8dyrd_10"
+PCCS_REDIRECT_URI = "polestar-explore://explore.polestar.com"
+PCCS_SCOPE = "openid profile email customer:attributes customer:attributes:write"
+PCCS_ACR_VALUES = "urn:volvoid:aal:bronze:2sv"
+
+HTTP_TIMEOUT = 30
+
+
+def b64urlencode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def main():
+    email = sys.argv[1] if len(sys.argv) > 1 else input("Email: ")
+    password = getpass.getpass("Password: ")
+
+    code_verifier = b64urlencode(os.urandom(32))
+    code_challenge = b64urlencode(hashlib.sha256(code_verifier.encode()).digest())
+    state = b64urlencode(os.urandom(12))
+
+    session = requests.Session()
+
+    # Step 1: Start auth
+    print("\n[1] Starting PCCS auth session...")
+    resp = session.get(
+        OIDC_AUTH_URL,
+        params={
+            "client_id": PCCS_CLIENT_ID,
+            "redirect_uri": PCCS_REDIRECT_URI,
+            "response_type": "code",
+            "state": state,
+            "scope": PCCS_SCOPE,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "acr_values": PCCS_ACR_VALUES,
+        },
+        allow_redirects=True,
+        timeout=HTTP_TIMEOUT,
+    )
+    resp.raise_for_status()
+    print(f"    Status: {resp.status_code}")
+    print(f"    URL: {resp.url}")
+
+    # Find resume URL
+    match = re.search(r"(/as/[^/]+/resume/as/authorization\.ping)", resp.text)
+    if not match:
+        print("    ERROR: Could not find resume URL")
+        sys.exit(1)
+    resume_url = OIDC_BASE_URL + match.group(1)
+    print(f"    Resume URL: {resume_url}")
+
+    # Step 2: Submit credentials
+    print("\n[2] Submitting credentials...")
+    resp = session.post(
+        resume_url,
+        data={
+            "pf.username": email,
+            "pf.pass": password,
+            "client_id": PCCS_CLIENT_ID,
+        },
+        allow_redirects=False,
+        timeout=HTTP_TIMEOUT,
+    )
+    print(f"    Status: {resp.status_code}")
+    print(f"    Location: {resp.headers.get('Location', 'none')}")
+
+    if resp.status_code in (302, 303):
+        print("    No 2FA required (got redirect)")
+        sys.exit(0)
+
+    if "ERR001" in resp.text or "authMessage" in resp.text:
+        print("    ERROR: Invalid credentials")
+        sys.exit(1)
+
+    # Step 3: Detect OTP challenge
+    print("\n[3] Analyzing OTP page...")
+    print(f"    Page length: {len(resp.text)} chars")
+
+    # Check JS action pattern (what the integration uses)
+    js_action = re.search(
+        r'action:\s*"(/as/[^"]+/resume/as/authorization\.ping)"',
+        resp.text,
+    )
+    print(f"    JS action pattern found: {bool(js_action)}")
+
+    # Check HTML form action pattern
+    html_action = re.search(
+        r'action="(/as/[^"]+/resume/as/authorization\.ping)"',
+        resp.text,
+    )
+    print(f"    HTML form action found: {bool(html_action)}")
+
+    # Find ALL input fields
+    inputs = re.findall(r'<input[^>]*>', resp.text)
+    print(f"    HTML input elements: {len(inputs)}")
+    for inp in inputs:
+        print(f"      {inp}")
+
+    # Find JS field references
+    js_names = re.findall(
+        r'(?:name|fieldName|field|param|key)["\']?\s*[:=]\s*["\']([^"\']+)["\']',
+        resp.text,
+    )
+    print(f"    JS name/field references: {js_names}")
+
+    # Find fetch/POST patterns
+    fetch_patterns = re.findall(r'fetch\([^)]+\)', resp.text)
+    print(f"    fetch() calls: {len(fetch_patterns)}")
+    for fp in fetch_patterns[:5]:
+        print(f"      {fp[:200]}")
+
+    # Find JSON.stringify patterns
+    stringify = re.findall(r'JSON\.stringify\(([^)]+)\)', resp.text)
+    print(f"    JSON.stringify patterns: {stringify[:5]}")
+
+    # Find any "otp" references
+    otp_refs = re.findall(r'.{0,40}otp.{0,40}', resp.text, re.IGNORECASE)
+    print(f"    'otp' references ({len(otp_refs)}):")
+    for ref in otp_refs[:10]:
+        print(f"      {ref.strip()}")
+
+    # Dump key parts of the page
+    print("\n    --- Page content (first 3000 chars) ---")
+    print(resp.text[:3000])
+    print("    --- End ---")
+
+    otp_resume = OIDC_BASE_URL + (js_action or html_action).group(1)
+    print(f"\n    OTP resume URL: {otp_resume}")
+
+    # Step 4: Get OTP from user and submit
+    otp_code = input("\n[4] Enter OTP code from email: ").strip()
+
+    print(f"\n[5] Submitting OTP '{otp_code}' to {otp_resume}")
+
+    # Try the current approach first (form POST with "otp" field)
+    print("\n    --- Attempt A: POST form data {'otp': code} ---")
+    resp_a = session.post(
+        otp_resume,
+        data={"otp": otp_code},
+        allow_redirects=False,
+        timeout=HTTP_TIMEOUT,
+    )
+    print(f"    Status: {resp_a.status_code}")
+    print(f"    Location: {resp_a.headers.get('Location', 'none')}")
+    loc_a = resp_a.headers.get("Location", "")
+    if "code=" in loc_a:
+        print("    SUCCESS with form data {'otp': code}!")
+    elif "error" in loc_a:
+        parsed = urlparse(loc_a)
+        params = parse_qs(parsed.query)
+        print(f"    FAILED: {params.get('error', ['?'])} - {params.get('error_description', ['?'])}")
+    if "otp-success-form" in resp_a.text:
+        print("    Has otp-success-form!")
+
+    print(f"\n    Response body length: {len(resp_a.text)}")
+    if resp_a.text:
+        print(f"    Response body (first 1000): {resp_a.text[:1000]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "polestar-soc"
+version = "1.0.0"
+source = { virtual = "." }


### PR DESCRIPTION
## Summary

The OTP 2FA flow fails with `Authentication failed.` (`access_denied`) because the PingFederate OTP page requires a CSRF token (`cSRFToken`) alongside the OTP code. The success continuation page also requires its own CSRF token. Neither was being sent.

## Root cause

The OTP challenge page (`otp.adapter.otp.required.template.html`) sets a `cSRFToken` in `window.globalContext`. The JS frontend reads it and includes it as a hidden form field when POSTing the OTP code. The integration was only sending `{"otp": code}` without the token.

After a successful OTP, PingFederate returns a success page (`otp.adapter.otp.verified.template.html`) with an auto-submit form containing `continue.authentication=true` and a new `cSRFToken`. The integration was only sending `continue.authentication` without the token.

Without these tokens, PingFederate rejects the requests and redirects to `polestar-explore://explore.polestar.com?error=access_denied`. The integration then crashes with `requests.exceptions.InvalidSchema` because it tries to HTTP GET a `polestar-explore://` URL.

## Changes

- `_detect_otp_challenge` now extracts the CSRF token from the OTP page's `globalContext` and returns it as a `(url, csrf_token)` tuple
- `_submit_otp` accepts and sends `cSRFToken` with the OTP POST
- `_submit_otp` extracts and sends the success page's `cSRFToken` in the continue POST
- `_extract_auth_code` handles non-HTTP redirect URLs gracefully and parses error information from the query string instead of crashing
- `login_start_2fa` stores the CSRF token in the session state for `login_complete_2fa` to use

## Testing

Verified locally by running the full PCCS 2FA flow (auth session, credentials, OTP with CSRF, continue with CSRF) and successfully obtaining an authorization code. Also tested on a live Home Assistant instance.